### PR TITLE
fix: Add trailing slash, be explicit about this via config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,8 @@ export const locales = {
 
 // https://astro.build/config
 export default defineConfig({
+  output: "static",
+  trailingSlash: "always",
   devToolbar: {
     enabled: false,
   },

--- a/src/content/docs/guides/getting-started.md
+++ b/src/content/docs/guides/getting-started.md
@@ -59,12 +59,12 @@ Enterprise policies do not need to be bundled with the Firefox installer, but ca
 For more information, see the [Configuring policies](/guides/policies-configuration/) guide.
 Common policies include:
 
-- [`DisableAppUpdate`](/reference/policies/disableappupdate) - lock Firefox to a known version
-- [`Certificates`](/reference/policies/certificates) - import or trust custom root CAs
-- [`BlockAboutConfig`](/reference/policies/blockaboutconfig) - prevent users from modifying advanced preferences
-- [`Homepage`](/reference/policies/homepage) - set a company homepage
-- [`Extensions`](/reference/policies/extensions) - force-install approved extensions
-- [`Proxy`](/reference/policies/proxy) - configure proxy settings or enforce a PAC file
+- [`DisableAppUpdate`](/reference/policies/disableappupdate/) - lock Firefox to a known version
+- [`Certificates`](/reference/policies/certificates/) - import or trust custom root CAs
+- [`BlockAboutConfig`](/reference/policies/blockaboutconfig/) - prevent users from modifying advanced preferences
+- [`Homepage`](/reference/policies/homepage/) - set a company homepage
+- [`Extensions`](/reference/policies/extensions/) - force-install approved extensions
+- [`Proxy`](/reference/policies/proxy/) - configure proxy settings or enforce a PAC file
 
 For a list of available policies, see the [policy reference](/reference/policies/).
 Additionally, policy templates are available for Windows, macOS, and Linux in the [github.com/mozilla/policy-templates](https://github.com/mozilla/policy-templates) repository.

--- a/src/content/docs/reference/policies/AppAutoUpdate.mdx
+++ b/src/content/docs/reference/policies/AppAutoUpdate.mdx
@@ -10,7 +10,7 @@ If set to `true`, application updates are installed without user approval within
 
 If set to `false`, application updates are downloaded but the user can choose when to install the update.
 
-If you have disabled updates via [`DisableAppUpdate`](/reference/policies/disableappupdate), this policy has no effect.
+If you have disabled updates via [`DisableAppUpdate`](/reference/policies/disableappupdate/), this policy has no effect.
 
 **Compatibility:** Firefox 75, Firefox ESR 68.7\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/BackgroundAppUpdate.mdx
+++ b/src/content/docs/reference/policies/BackgroundAppUpdate.mdx
@@ -14,7 +14,7 @@ If set to `false`, the application will not try to install updates when the appl
 If you are having trouble getting the background task to run, verify your configuration with the ["Requirements to run" section in this support document](https://support.mozilla.org/en-US/kb/enable-background-updates-firefox-windows).
 
 > [!NOTE]
-> The `BackgroundAppUpdate` policy has no effect if you have disabled updates via the [`DisableAppUpdate`](/reference/policies/disableappupdate) policy or disabled automatic updates via the [`AppAutoUpdate`](/reference/policies/appautoupdate) policy.
+> The `BackgroundAppUpdate` policy has no effect if you have disabled updates via the [`DisableAppUpdate`](/reference/policies/disableappupdate/) policy or disabled automatic updates via the [`AppAutoUpdate`](/reference/policies/appautoupdate/) policy.
 
 **Compatibility:** Firefox 90 (Windows only)\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/Bookmarks.mdx
+++ b/src/content/docs/reference/policies/Bookmarks.mdx
@@ -5,7 +5,7 @@ category: "Bookmarks"
 ---
 
 > [!WARNING]
-> The [`ManagedBookmarks`](/reference/policies/managedbookmarks) policy is the recommended way to add bookmarks.
+> The [`ManagedBookmarks`](/reference/policies/managedbookmarks/) policy is the recommended way to add bookmarks.
 > The `Bookmarks` policy will continue to be supported for backwards-compatibility purposes.
 
 Add bookmarks in either the bookmarks toolbar or menu. Only `Title` and `URL` are required. If `Placement` is not specified, the bookmark will be placed on the toolbar. If `Folder` is specified, it is automatically created and bookmarks with the same folder name are grouped together.

--- a/src/content/docs/reference/policies/Certificates_ImportEnterpriseRoots.mdx
+++ b/src/content/docs/reference/policies/Certificates_ImportEnterpriseRoots.mdx
@@ -60,5 +60,5 @@ Value (string):
 
 ## See also
 
-- [Certificates: Install](/reference/policies/certificates--install) policy
+- [Certificates: Install](/reference/policies/certificates--install/) policy
 - [Set up Certificate Authorities (CAs) in Firefox](https://support.mozilla.org/kb/setting-certificate-authorities-firefox) on support.mozilla.org (SUMO)

--- a/src/content/docs/reference/policies/Certificates_Install.mdx
+++ b/src/content/docs/reference/policies/Certificates_Install.mdx
@@ -85,4 +85,4 @@ Value (string):
 
 ## See also
 
-- [Certificates: ImportEnterpriseRoots](/reference/policies/certificates--importenterpriseroots) policy
+- [Certificates: ImportEnterpriseRoots](/reference/policies/certificates--importenterpriseroots/) policy

--- a/src/content/docs/reference/policies/Cookies.mdx
+++ b/src/content/docs/reference/policies/Cookies.mdx
@@ -28,7 +28,7 @@ Configure cookie preferences.
 - `Default`: determines whether cookies are accepted at all. (_Deprecated_. Use `Behavior` instead)
 - `AcceptThirdParty` determines how third-party cookies are handled. (_Deprecated_. Use `Behavior` instead)
 - `RejectTracker` only rejects cookies for trackers. (_Deprecated_. Use `Behavior` instead)
-- `ExpireAtSessionEnd` determines when cookies expire. (_Deprecated_. Use [`SanitizeOnShutdown`](/reference/policies/sanitizeonshutdown-selective) instead)
+- `ExpireAtSessionEnd` determines when cookies expire. (_Deprecated_. Use [`SanitizeOnShutdown`](/reference/policies/sanitizeonshutdown-selective/) instead)
 
 ## Windows (GPO)
 

--- a/src/content/docs/reference/policies/DisableBuiltinPDFViewer.mdx
+++ b/src/content/docs/reference/policies/DisableBuiltinPDFViewer.mdx
@@ -8,7 +8,7 @@ Disable the built in PDF viewer. PDF files are downloaded and sent externally.
 
 > [!NOTE] As of Firefox 140, this policy no longer completely disables PDF.js; it changes the handler to send PDF files to the operating system.
 > Embedded PDF files are shown in the browser.
-> If you need to completely disable PDF.js, you can use the [`PDFjs`](/reference/policies/pdfjs) policy.
+> If you need to completely disable PDF.js, you can use the [`PDFjs`](/reference/policies/pdfjs/) policy.
 
 **Compatibility:** Firefox 60, Firefox ESR 60\
 **CCK2 Equivalent:** `disablePDFjs`\

--- a/src/content/docs/reference/policies/DisableMasterPasswordCreation.mdx
+++ b/src/content/docs/reference/policies/DisableMasterPasswordCreation.mdx
@@ -6,9 +6,9 @@ category: "Password manager"
 
 Remove the master password functionality.
 
-If this value is `true`, it works the same as setting [`PrimaryPassword`](/reference/policies/primarypassword) to `false` and removes the primary password functionality.
+If this value is `true`, it works the same as setting [`PrimaryPassword`](/reference/policies/primarypassword/) to `false` and removes the primary password functionality.
 
-If both `DisableMasterPasswordCreation` and [`PrimaryPassword`](/reference/policies/primarypassword) are used, `DisableMasterPasswordCreation` takes precedence.
+If both `DisableMasterPasswordCreation` and [`PrimaryPassword`](/reference/policies/primarypassword/) are used, `DisableMasterPasswordCreation` takes precedence.
 
 **Compatibility:** Firefox 60, Firefox ESR 60\
 **CCK2 Equivalent:** `noMasterPassword`\
@@ -55,4 +55,4 @@ Value (string):
 
 ## See also
 
-- [`PrimaryPassword`](/reference/policies/primarypassword) policy
+- [`PrimaryPassword`](/reference/policies/primarypassword/) policy

--- a/src/content/docs/reference/policies/DisablePrivateBrowsing.mdx
+++ b/src/content/docs/reference/policies/DisablePrivateBrowsing.mdx
@@ -6,7 +6,7 @@ category: "Browsing restrictions"
 
 Remove access to private browsing.
 
-This policy is superseded by the [`PrivateBrowsingModeAvailability`](/reference/policies/privatebrowsingmodeavailability) policy.
+This policy is superseded by the [`PrivateBrowsingModeAvailability`](/reference/policies/privatebrowsingmodeavailability/) policy.
 
 **Compatibility:** Firefox 60, Firefox ESR 60\
 **CCK2 Equivalent:** `disablePrivateBrowsing`\

--- a/src/content/docs/reference/policies/Extensions.mdx
+++ b/src/content/docs/reference/policies/Extensions.mdx
@@ -7,7 +7,7 @@ category: "Extensions"
 Control the installation, uninstallation and locking of extensions.
 
 > [!WARNING]
-> The **[`ExtensionSettings`](/reference/policies/extensionsettings)** policy was added in Firefox 69.
+> The **[`ExtensionSettings`](/reference/policies/extensionsettings/)** policy was added in Firefox 69.
 > It provides additional functionality to `Extensions` and is closer in compatibility to Chrome and Edge.
 > It does not support native paths, so you'll have to use `file://` URLs.
 > Before using `Extensions`, it's recommended to use `ExtensionSettings` as all future improvements will be applied to that policy instead.

--- a/src/content/docs/reference/policies/ManualAppUpdateOnly.mdx
+++ b/src/content/docs/reference/policies/ManualAppUpdateOnly.mdx
@@ -10,7 +10,7 @@ If this policy is enabled:
 
 1. The user will never be prompted to install updates
 2. Firefox will not check for updates in the background, though it will check automatically when an update UI is displayed (such as the one in the About dialog). This check will be used to show "Update to version X" in the UI, but will not automatically download the update or prompt the user to update in any other way.
-3. The update UI will work as expected, unlike when using the [`DisableAppUpdate`](/reference/policies/disableappupdate) policy.
+3. The update UI will work as expected, unlike when using the [`DisableAppUpdate`](/reference/policies/disableappupdate/) policy.
 
 This policy is primarily intended for advanced end users, not for enterprises, but it is available via GPO.
 

--- a/src/content/docs/reference/policies/PrimaryPassword.mdx
+++ b/src/content/docs/reference/policies/PrimaryPassword.mdx
@@ -7,7 +7,7 @@ category: "Password manager"
 Require or prevent using a primary (formerly master) password.
 
 If this value is true, a primary password is required.
-If this value is false, it works the same as if [`DisableMasterPasswordCreation`](/reference/policies/disablemasterpasswordcreation) was true and removes the primary password functionality.
+If this value is false, it works the same as if [`DisableMasterPasswordCreation`](/reference/policies/disablemasterpasswordcreation/) was true and removes the primary password functionality.
 
 If both `DisableMasterPasswordCreation` and `PrimaryPassword` are used, `DisableMasterPasswordCreation` takes precedence.
 

--- a/src/content/docs/reference/policies/PrivateBrowsingModeAvailability.mdx
+++ b/src/content/docs/reference/policies/PrivateBrowsingModeAvailability.mdx
@@ -6,7 +6,7 @@ category: "Browsing restrictions"
 
 Set availability of private browsing mode.
 
-This policy supersedes [`DisablePrivateBrowsing`](/reference/policies/disableprivatebrowsing)
+This policy supersedes [`DisablePrivateBrowsing`](/reference/policies/disableprivatebrowsing/)
 
 > [!NOTE] This policy missed Firefox ESR 128.2, but it will be in Firefox ESR 128.3.
 

--- a/src/content/docs/reference/policies/SanitizeOnShutdown_All.mdx
+++ b/src/content/docs/reference/policies/SanitizeOnShutdown_All.mdx
@@ -52,4 +52,4 @@ Value (string):
 
 ## See also
 
-- [`SanitizeOnShutdown` (Selective)](/reference/policies/sanitizeonshutdown-selective) policy
+- [`SanitizeOnShutdown` (Selective)](/reference/policies/sanitizeonshutdown-selective/) policy

--- a/src/content/docs/reference/policies/SanitizeOnShutdown_Selective.mdx
+++ b/src/content/docs/reference/policies/SanitizeOnShutdown_Selective.mdx
@@ -169,4 +169,4 @@ Value (string):
 
 ## See also
 
-- [`SanitizeOnShutdown` (All)](/reference/policies/sanitizeonshutdown-all) policy
+- [`SanitizeOnShutdown` (All)](/reference/policies/sanitizeonshutdown-all/) policy

--- a/src/content/docs/reference/policies/SearchEngines_Add.mdx
+++ b/src/content/docs/reference/policies/SearchEngines_Add.mdx
@@ -116,4 +116,4 @@ Value (string):
 
 ## See also
 
-- **[SearchEngines](/reference/policies/searchengines):** All search-related policies.
+- **[SearchEngines](/reference/policies/searchengines/):** All search-related policies.

--- a/src/content/docs/reference/policies/SearchEngines_Default.mdx
+++ b/src/content/docs/reference/policies/SearchEngines_Default.mdx
@@ -58,4 +58,4 @@ Value (string):
 
 ## See also
 
-- **[SearchEngines](/reference/policies/searchengines):** All search-related policies.
+- **[SearchEngines](/reference/policies/searchengines/):** All search-related policies.

--- a/src/content/docs/reference/policies/SearchEngines_PreventInstalls.mdx
+++ b/src/content/docs/reference/policies/SearchEngines_PreventInstalls.mdx
@@ -57,4 +57,4 @@ Value (string):
 
 ## See also
 
-- **[SearchEngines](/reference/policies/searchengines):** All search-related policies.
+- **[SearchEngines](/reference/policies/searchengines/):** All search-related policies.

--- a/src/content/docs/reference/policies/SearchEngines_Remove.mdx
+++ b/src/content/docs/reference/policies/SearchEngines_Remove.mdx
@@ -60,4 +60,4 @@ Value (string):
 
 ## See also
 
-- **[SearchEngines](/reference/policies/searchengines):** All search-related policies.
+- **[SearchEngines](/reference/policies/searchengines/):** All search-related policies.

--- a/src/content/docs/reference/policies/TranslateEnabled.mdx
+++ b/src/content/docs/reference/policies/TranslateEnabled.mdx
@@ -8,7 +8,7 @@ Enable or disable webpage translation.
 
 > [!NOTE] Web page translation is performed entirely client-side, so there is no data or privacy risk transmitting content to a translation service over the network.
 
-If you only want to disable the popup, you can set the `browser.translations.automaticallyPopup` preference to `false` using the [Preferences](/reference/policies/preferences) policy.
+If you only want to disable the popup, you can set the `browser.translations.automaticallyPopup` preference to `false` using the [Preferences](/reference/policies/preferences/) policy.
 
 **Compatibility:** Firefox 126\
 **CCK2 Equivalent:** N/A\


### PR DESCRIPTION
**Description:**

__Changes:__
* Fix some internal xrefs without trailing slash
* Add a config for `trailingSlash` so that we catch deviations during builds

**Motivation:**

Some internal links were broken because of the missing trailing slash. This is flexible in config, but leads to broken links in static builds on prod.
