### PR TITLE
feat: Add localnetworkaccess policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
 
 - Sync policy [#70](https://github.com/mozilla/enterprise-admin-reference/pull/70)
 
+## fx-149.0.0
+
+### Added
+
+- `LocalNetworkAccess`: Configure local network access security features. ([#67](https://github.com/mozilla/enterprise-admin-reference/pull/67))
+
 ## fx-148.0.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 - Sync policy [#70](https://github.com/mozilla/enterprise-admin-reference/pull/70)
 
-## fx-149.0.0
+## fx-150.0.0
 
 ### Added
 

--- a/src/content/docs/reference/policies/LocalNetworkAccess.mdx
+++ b/src/content/docs/reference/policies/LocalNetworkAccess.mdx
@@ -1,0 +1,165 @@
+---
+title: "LocalNetworkAccess"
+description: "Configure local network access security features."
+category: "Network security"
+---
+
+Configure local network access security features.
+The `LocalNetworkAccess` policy controls Firefox's behavior when websites attempt to access local network resources (localhost and local network addresses).
+
+**Compatibility:** Firefox 147\
+**CCK2 Equivalent:** N/A\
+**Preferences Affected:** `network.lna.enabled`, `network.lna.block_trackers`, `network.lna.blocking`, `network.lna.skip-domains`
+
+## Values
+
+- `Enabled`: a Boolean that enables or disables the policy.
+  - When `true` (default), Firefox enforces local network access security checks.
+    This is the base flag without which none of the local network access checks below would be enforced.
+  - When `false`, all local network access checks are disabled and websites can freely access local network resources.
+- `BlockTrackers`: a Boolean that controls blocking third-party trackers. When `true`, third-party trackers are directly blocked from accessing localhost and local network resources.
+  This is an experimental feature that helps prevent tracking scripts from scanning your local network.
+- `EnablePrompting`: a Boolean to gate user permission prompts.
+  When `true`, access to local network resources will be explicitly gated via user permission prompts.
+  Users will be asked to grant permission before a website can access local resources.
+- `SkipDomains`: an array of domain names for which local network access checks should be skipped. This allows administrators to create exceptions for trusted domains.
+- `Locked`: if set to true, users cannot change the local network access settings.
+
+## Description
+
+When providing a list of exceptions for trusted domains, the `SkipDomains` array can contain both **source domains** (the website making the request) and **target domains** (the local resource being accessed).
+
+When a **source domain** is listed, that website is allowed to access local network resources without restrictions.
+For example, if `"trusted-app.example.com"` is listed, that website can freely make requests to any local network resources.
+
+When a **target domain** is listed, any website can access that specific local network resource without restrictions.
+For example, if `"printer.local"` is listed, all websites can access the printer device.
+
+Suffix wildcard patterns for are supported using the `*.` prefix to match all subdomains:
+
+- `"*.company.com"` - Skips checks for all subdomains of company.com (matches `app.company.com`, `portal.company.com`, etc.).
+- `"*.internal"` - Skips checks for all .internal domains (matches `device.internal`, `printer.internal`, etc.).
+- `"web-app.example.com"` - Skips checks for this specific domain only (no subdomain matching).
+- `"*.devices.local"` - Allows access to all local devices with `.devices.local` suffix (`printer.devices.local`, `scanner.devices.local`, etc.).
+- `"*.corp.internal"` - Allows access to all corporate internal domains.
+
+#### Windows (GPO)
+
+```
+Software\Policies\Mozilla\Firefox\LocalNetworkAccess\Enabled = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\LocalNetworkAccess\BlockTrackers = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\LocalNetworkAccess\EnablePrompting = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\LocalNetworkAccess\SkipDomains\1 = "intranet.company.com"
+Software\Policies\Mozilla\Firefox\LocalNetworkAccess\SkipDomains\2 = "*.devices.local"
+Software\Policies\Mozilla\Firefox\LocalNetworkAccess\SkipDomains\3 = "*.corp.internal"
+Software\Policies\Mozilla\Firefox\LocalNetworkAccess\Locked = 0x1 | 0x0
+```
+
+#### Windows (Intune)
+
+OMA-URI:
+
+```
+./Device/Vendor/MSFT/Policy/Config/Firefox~Policy~firefox/LocalNetworkAccess_Enabled
+```
+
+Value (string):
+
+```
+<enabled/> or <disabled/>
+```
+
+OMA-URI:
+
+```
+./Device/Vendor/MSFT/Policy/Config/Firefox~Policy~firefox/LocalNetworkAccess_BlockTrackers
+```
+
+Value (string):
+
+```
+<enabled/> or <disabled/>
+```
+
+OMA-URI:
+
+```
+./Device/Vendor/MSFT/Policy/Config/Firefox~Policy~firefox/LocalNetworkAccess_EnablePrompting
+```
+
+Value (string):
+
+```
+<enabled/> or <disabled/>
+```
+
+OMA-URI:
+
+```
+./Device/Vendor/MSFT/Policy/Config/Firefox~Policy~firefox/LocalNetworkAccess_SkipDomains
+```
+
+Value (string):
+
+```
+<enabled/>
+<data id="LocalNetworkAccess_SkipDomains" value="1&#xF000;intranet.company.com&#xF000;2&#xF000;*.devices.local&#xF000;3&#xF000;*.corp.internal"/>
+```
+
+OMA-URI:
+
+```
+./Device/Vendor/MSFT/Policy/Config/Firefox~Policy~firefox/LocalNetworkAccess_Locked
+```
+
+Value (string):
+
+```
+<enabled/> or <disabled/>
+```
+
+#### macOS
+
+```
+<dict>
+  <key>LocalNetworkAccess</key>
+  <dict>
+    <key>Enabled</key>
+    <true/> | <false/>
+    <key>BlockTrackers</key>
+    <true/> | <false/>
+    <key>EnablePrompting</key>
+    <true/> | <false/>
+    <key>SkipDomains</key>
+    <array>
+      <string>intranet.company.com</string>
+      <string>*.devices.local</string>
+      <string>admin-portal.enterprise.com</string>
+      <string>*.corp.internal</string>
+    </array>
+    <key>Locked</key>
+    <true/> | <false/>
+  </dict>
+</dict>
+```
+
+#### policies.json
+
+```
+{
+  "policies": {
+    "LocalNetworkAccess": {
+      "Enabled": true | false,
+      "BlockTrackers": true | false,
+      "EnablePrompting": true | false,
+      "SkipDomains": [
+        "intranet.company.com",
+        "*.devices.local",
+        "admin-portal.enterprise.com",
+        "*.corp.internal"
+      ],
+      "Locked": true | false
+    }
+  }
+}
+```

--- a/src/content/docs/reference/policies/LocalNetworkAccess.mdx
+++ b/src/content/docs/reference/policies/LocalNetworkAccess.mdx
@@ -7,7 +7,7 @@ category: "Network security"
 Configure local network access security features.
 The `LocalNetworkAccess` policy controls Firefox's behavior when websites attempt to access local network resources (localhost and local network addresses).
 
-**Compatibility:** Firefox 147\
+**Compatibility:** Firefox 149\
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.lna.enabled`, `network.lna.block_trackers`, `network.lna.blocking`, `network.lna.skip-domains`
 

--- a/src/content/docs/reference/policies/LocalNetworkAccess.mdx
+++ b/src/content/docs/reference/policies/LocalNetworkAccess.mdx
@@ -7,7 +7,7 @@ category: "Network security"
 Configure local network access security features.
 The `LocalNetworkAccess` policy controls Firefox's behavior when websites attempt to access local network resources (localhost and local network addresses).
 
-**Compatibility:** Firefox 149\
+**Compatibility:** Firefox 150\
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.lna.enabled`, `network.lna.block_trackers`, `network.lna.blocking`, `network.lna.skip-domains`
 


### PR DESCRIPTION
**Description:**

This PR ports over changes from https://github.com/mozilla/policy-templates/pull/1288

**Motivation:**

The localnetworkaccess policy is missing.

**Related issues and pull requests:**

- [x] https://github.com/mozilla/enterprise-admin-reference/issues/17
- [x] https://github.com/mozilla/enterprise-admin-reference/issues/57

CC @MayyaSunil 

Fixes #17
