### PR TITLE
feat(docs): Add AccessConnector policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@
 
 #### Added
 
+- `AccessConnector` policy: Configure an Access Connector for proxying web traffic. [#102](https://github.com/mozilla/enterprise-admin-reference/pull/102)
 - `AIControls` policy: Configure AI controls. [#103](https://github.com/mozilla/enterprise-admin-reference/pull/103)
 - `CrashReportsSubmit` policy: Configure crash report submission settings. [#86](https://github.com/mozilla/enterprise-admin-reference/pull/86)
-- `Sync` policy [#70](https://github.com/mozilla/enterprise-admin-reference/pull/70)
+- `Sync` policy: Enable or disable sync and define which data to include. [#70](https://github.com/mozilla/enterprise-admin-reference/pull/70)
 
 ## fx-150.0.0
 

--- a/src/content/docs/reference/policies/AccessConnector.mdx
+++ b/src/content/docs/reference/policies/AccessConnector.mdx
@@ -1,7 +1,7 @@
 ---
 title: "AccessConnector"
 description: "Configure an Access Connector for proxying web traffic."
-category: "Miscellaneous"
+category: "Network Security"
 ---
 
 Configure an Access Connector for proxying web traffic.

--- a/src/content/docs/reference/policies/AccessConnector.mdx
+++ b/src/content/docs/reference/policies/AccessConnector.mdx
@@ -1,0 +1,67 @@
+---
+title: "AccessConnector"
+description: "Configure an Access Connector for proxying web traffic."
+category: "Miscellaneous"
+---
+
+Configure an Access Connector for proxying web traffic.
+When this policy is set, Firefox traffic matching the specified URL patterns is routed through the configured proxy.
+
+> [!NOTE]
+> Currently, this is only implemented in Firefox Enterprise.
+
+**Compatibility:** Firefox Enterprise 149.0.0\
+**CCK2 Equivalent:** N/A\
+**Preferences Affected:** N/A
+
+## Values
+
+- `Host`: A string that defines the hostname or IP address of the proxy server to use.
+- `Port`: A number defining the port number of the proxy server (e.g., `443`).
+- `MatchPatterns`: A list of URL match patterns for which traffic should be routed through the Access Connector.
+  See [Match patterns](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns) for syntax.
+- `Locked`: Prevents the user from changing Access Connector settings.
+
+## Windows (GPO)
+
+```
+Software\Policies\Mozilla\Firefox\AccessConnector\Host = "proxy.example.com"
+Software\Policies\Mozilla\Firefox\AccessConnector\Port = 443
+Software\Policies\Mozilla\Firefox\AccessConnector\MatchPatterns\1 = "https://*.example.com"
+Software\Policies\Mozilla\Firefox\AccessConnector\Locked = 0x1 | 0x0
+```
+
+## macOS
+
+```xml
+<dict>
+  <key>AccessConnector</key>
+  <dict>
+    <key>Host</key>
+    <string>proxy.example.com</string>
+    <key>Port</key>
+    <integer>443</integer>
+    <key>MatchPatterns</key>
+    <array>
+      <string>https://*.example.com</string>
+    </array>
+    <key>Locked</key>
+    <true/> | <false/>
+  </dict>
+</dict>
+```
+
+## policies.json
+
+```json
+{
+  "policies": {
+    "AccessConnector": {
+      "Host": "proxy.example.com",
+      "Port": 443,
+      "MatchPatterns": ["https://*.example.com"],
+      "Locked": true | false
+    }
+  }
+}
+```


### PR DESCRIPTION
**Description:**

Add missing `AccessConnector` page

__Release:__ Enterprise 149

**Motivation:**

Missing a docs page for it.

**Related issues and pull requests:**

- [x] https://github.com/mozilla/enterprise-firefox/pull/562

Fixes https://github.com/mozilla/enterprise-admin-reference/issues/101