### PR TITLE
feat(docs): Add AIChatbot policy

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -11,6 +11,7 @@ browser.newtabpage
 browser.newtabpage.activity-stream.asrouter
 browser.safebrowsing
 CHACHA
+chatbots
 cryptomining
 datareporting
 datareporting.healthreport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 #### Added
 
 - `AccessConnector` policy: Configure an Access Connector for proxying web traffic. [#102](https://github.com/mozilla/enterprise-admin-reference/pull/102)
-- `AIChatbot` policy: Configure the AI chatbot sidebar. [#TBD](https://github.com/mozilla/enterprise-admin-reference/pull/TBD)
+- `AIChatbot` policy: Configure the AI chatbot sidebar. [#106](https://github.com/mozilla/enterprise-admin-reference/pull/106)
 - `AIControls` policy: Configure AI controls. [#103](https://github.com/mozilla/enterprise-admin-reference/pull/103)
 - `CrashReportsSubmit` policy: Configure crash report submission settings. [#86](https://github.com/mozilla/enterprise-admin-reference/pull/86)
 - `Sync` policy: Enable or disable sync and define which data to include. [#70](https://github.com/mozilla/enterprise-admin-reference/pull/70)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 #### Added
 
 - `AccessConnector` policy: Configure an Access Connector for proxying web traffic. [#102](https://github.com/mozilla/enterprise-admin-reference/pull/102)
+- `AIChatbot` policy: Configure the AI chatbot sidebar. [#TBD](https://github.com/mozilla/enterprise-admin-reference/pull/TBD)
 - `AIControls` policy: Configure AI controls. [#103](https://github.com/mozilla/enterprise-admin-reference/pull/103)
 - `CrashReportsSubmit` policy: Configure crash report submission settings. [#86](https://github.com/mozilla/enterprise-admin-reference/pull/86)
 - `Sync` policy: Enable or disable sync and define which data to include. [#70](https://github.com/mozilla/enterprise-admin-reference/pull/70)

--- a/src/content/docs/reference/policies/AIChatbot.mdx
+++ b/src/content/docs/reference/policies/AIChatbot.mdx
@@ -1,0 +1,172 @@
+---
+title: "AIChatbot"
+description: "Configure the AI chatbot sidebar."
+category: "Content settings"
+---
+
+Configure the AI chatbot sidebar, including which built-in providers are available and the ability to add custom providers.
+
+> [!NOTE]
+> Currently, this is only implemented in Firefox Enterprise.
+
+**Compatibility:** Firefox Enterprise 149.0.0\
+**CCK2 Equivalent:** N/A\
+**Preferences Affected:** `browser.ml.chat.enabled`, `browser.ml.chat.provider`, `browser.ml.chat.providers`, `browser.ml.chat.shortcuts`, `browser.ml.chat.prompts.0`, `browser.ml.chat.prompts.1`, `browser.ml.chat.prompts.2`, `browser.ml.chat.prompts.3`
+
+## Values
+
+- `Providers`: Configures the available AI chatbot providers.
+  - `Add`: An array of custom provider objects to add.
+    Each object accepts the following properties:
+    - `url` (required): The URL of the AI chatbot provider.
+    - `name` (required): Display name for the provider.
+    - `id` (required): Unique identifier for the provider.
+    - `iconUrl`: URL of the provider's icon.
+    - `queryParam`: Query parameter name used to pass prompts to the provider.
+  - `BuiltIn`: An object to enable or disable individual built-in providers.
+    Set a provider key to `true` to enable it or `false` to disable it.
+    The following built-in providers are available:
+    - `Anthropic Claude`
+    - `ChatGPT`
+    - `Copilot`
+    - `Google Gemini`
+    - `HuggingChat`
+    - `Le Chat Mistral`
+    - `localhost`
+  - `Default`: The `id` of the provider to use as the default.
+- `Prompts`: Configures the AI chatbot prompt suggestions.
+  - `Enabled`: Set to `true` to enable prompt suggestions or `false` to disable them.
+  - `BuiltIn`: An object to enable or disable individual built-in prompts.
+    Set a prompt key to `true` to enable it or `false` to disable it.
+    The following built-in prompts are available:
+    - `Summarize`
+    - `Explain`
+    - `Quiz`
+    - `Proofread`
+
+## Windows (GPO)
+
+```
+Software\Policies\Mozilla\Firefox\AIChatbot\Providers\Add\1\url = "https://example.com"
+Software\Policies\Mozilla\Firefox\AIChatbot\Providers\Add\1\name = "Example AI"
+Software\Policies\Mozilla\Firefox\AIChatbot\Providers\Add\1\id = "example-ai"
+Software\Policies\Mozilla\Firefox\AIChatbot\Providers\Add\1\iconUrl = "https://example.com/icon.png"
+Software\Policies\Mozilla\Firefox\AIChatbot\Providers\Add\1\queryParam = "q"
+Software\Policies\Mozilla\Firefox\AIChatbot\Providers\BuiltIn\Anthropic Claude = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\AIChatbot\Providers\BuiltIn\ChatGPT = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\AIChatbot\Providers\BuiltIn\Copilot = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\AIChatbot\Providers\BuiltIn\Google Gemini = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\AIChatbot\Providers\BuiltIn\HuggingChat = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\AIChatbot\Providers\BuiltIn\Le Chat Mistral = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\AIChatbot\Providers\BuiltIn\localhost = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\AIChatbot\Providers\Default = "example-ai"
+Software\Policies\Mozilla\Firefox\AIChatbot\Prompts\Enabled = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\AIChatbot\Prompts\BuiltIn\Summarize = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\AIChatbot\Prompts\BuiltIn\Explain = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\AIChatbot\Prompts\BuiltIn\Quiz = 0x1 | 0x0
+Software\Policies\Mozilla\Firefox\AIChatbot\Prompts\BuiltIn\Proofread = 0x1 | 0x0
+```
+
+## macOS
+
+```xml
+<dict>
+  <key>AIChatbot</key>
+  <dict>
+    <key>Providers</key>
+    <dict>
+      <key>Add</key>
+      <array>
+        <dict>
+          <key>url</key>
+          <string>https://example.com</string>
+          <key>name</key>
+          <string>Example AI</string>
+          <key>id</key>
+          <string>example-ai</string>
+          <key>iconUrl</key>
+          <string>https://example.com/icon.png</string>
+          <key>queryParam</key>
+          <string>q</string>
+        </dict>
+      </array>
+      <key>BuiltIn</key>
+      <dict>
+        <key>Anthropic Claude</key>
+        <true/> | <false/>
+        <key>ChatGPT</key>
+        <true/> | <false/>
+        <key>Copilot</key>
+        <true/> | <false/>
+        <key>Google Gemini</key>
+        <true/> | <false/>
+        <key>HuggingChat</key>
+        <true/> | <false/>
+        <key>Le Chat Mistral</key>
+        <true/> | <false/>
+        <key>localhost</key>
+        <true/> | <false/>
+      </dict>
+      <key>Default</key>
+      <string>example-ai</string>
+    </dict>
+    <key>Prompts</key>
+    <dict>
+      <key>Enabled</key>
+      <true/> | <false/>
+      <key>BuiltIn</key>
+      <dict>
+        <key>Summarize</key>
+        <true/> | <false/>
+        <key>Explain</key>
+        <true/> | <false/>
+        <key>Quiz</key>
+        <true/> | <false/>
+        <key>Proofread</key>
+        <true/> | <false/>
+      </dict>
+    </dict>
+  </dict>
+</dict>
+```
+
+## policies.json
+
+```json
+{
+  "policies": {
+    "AIChatbot": {
+      "Providers": {
+        "Add": [
+          {
+            "url": "https://example.com",
+            "name": "Example AI",
+            "id": "example-ai",
+            "iconUrl": "https://example.com/icon.png",
+            "queryParam": "q"
+          }
+        ],
+        "BuiltIn": {
+          "Anthropic Claude": true | false,
+          "ChatGPT": true | false,
+          "Copilot": true | false,
+          "Google Gemini": true | false,
+          "HuggingChat": true | false,
+          "Le Chat Mistral": true | false,
+          "localhost": true | false
+        },
+        "Default": "example-ai"
+      },
+      "Prompts": {
+        "Enabled": true | false,
+        "BuiltIn": {
+          "Summarize": true | false,
+          "Explain": true | false,
+          "Quiz": true | false,
+          "Proofread": true | false
+        }
+      }
+    }
+  }
+}
+```

--- a/src/content/docs/reference/policies/AIChatbot.mdx
+++ b/src/content/docs/reference/policies/AIChatbot.mdx
@@ -5,6 +5,7 @@ category: "Content settings"
 ---
 
 Configure the AI chatbot sidebar, including which built-in providers are available and the ability to add custom providers.
+For more information, see [Access AI chatbots in Firefox](https://support.mozilla.org/en-US/kb/ai-chatbot) on support.mozilla.org.
 
 > [!NOTE]
 > Currently, this is only implemented in Firefox Enterprise.

--- a/src/content/docs/reference/policies/AIChatbot.mdx
+++ b/src/content/docs/reference/policies/AIChatbot.mdx
@@ -33,7 +33,7 @@ Configure the AI chatbot sidebar, including which built-in providers are availab
     - `HuggingChat`
     - `Le Chat Mistral`
     - `localhost`
-  - `Default`: The `id` of the provider to use as the default.
+  - `Default`: The `name` of the provider to use as the default.
 - `Prompts`: Configures the AI chatbot prompt suggestions.
   - `Enabled`: Set to `true` to enable prompt suggestions or `false` to disable them.
   - `BuiltIn`: An object to enable or disable individual built-in prompts.


### PR DESCRIPTION
**Description:**

Add missing `AIChatbot` page

__Release:__ Enterprise 149

For reviewers: I'm not sure of the GPO correctness, I'm extrapolating based on other policy docs.

**Motivation:**

Missing a docs page for it.

**Related issues and pull requests:**

- [x] https://github.com/mozilla/enterprise-firefox/pull/623

Fixes https://github.com/mozilla/enterprise-admin-reference/issues/102