### PR TITLE
fix: make content analysis policy JSON regex list valid

### DIFF
--- a/src/content/docs/reference/policies/ContentAnalysis.mdx
+++ b/src/content/docs/reference/policies/ContentAnalysis.mdx
@@ -337,35 +337,35 @@ Value (string):
       "AgentName": "My DLP Product",
       "AgentTimeout": 60,
       "AllowUrlRegexList": "https://example\\.com/.* https://subdomain\\.example\\.com/.*",
-      "BypassForSameTabOperations": false,
+      "BypassForSameTabOperations": true | false,
       "ClientSignature": "My DLP Company",
-      "DefaultResult": 0,
+      "DefaultResult": 0 | 1 | 2,
       "DenyUrlRegexList": "https://example\\.com/.* https://subdomain\\.example\\.com/.*",
-      "Enabled": true,
+      "Enabled": true | false,
       "InterceptionPoints": {
         "Clipboard": {
-          "Enabled": true,
-          "PlainTextOnly": true
+          "Enabled": true | false,
+          "PlainTextOnly": true | false
         },
         "Download": {
-          "Enabled": false
+          "Enabled": false | true,
         },
         "DragAndDrop": {
-          "Enabled": true,
-          "PlainTextOnly": true
+          "Enabled": true | false,
+          "PlainTextOnly": true | false
         },
         "FileUpload": {
-          "Enabled": true
+          "Enabled": true | false
         },
         "Print": {
-          "Enabled": true
+          "Enabled": true | false
         }
       },
-      "IsPerUser": true,
+      "IsPerUser": true | false,
       "MaxConnectionsCount": 32,
       "PipePathName": "pipe_custom_name",
-      "ShowBlockedResult": true,
-      "TimeoutResult": 0
+      "ShowBlockedResult": true | false,
+      "TimeoutResult": 0 | 1 | 2,
     }
   }
 }

--- a/src/content/docs/reference/policies/ContentAnalysis.mdx
+++ b/src/content/docs/reference/policies/ContentAnalysis.mdx
@@ -336,36 +336,36 @@ Value (string):
     "ContentAnalysis": {
       "AgentName": "My DLP Product",
       "AgentTimeout": 60,
-      "AllowUrlRegexList": "https://example\.com/.* https://subdomain\.example\.com/.*",
-      "BypassForSameTabOperations": true | false,
+      "AllowUrlRegexList": "https://example\\.com/.* https://subdomain\\.example\\.com/.*",
+      "BypassForSameTabOperations": false,
       "ClientSignature": "My DLP Company",
-      "DefaultResult": 0 | 1 | 2,
-      "DenyUrlRegexList": "https://example\.com/.* https://subdomain\.example\.com/.*",
-      "Enabled": true | false,
+      "DefaultResult": 0,
+      "DenyUrlRegexList": "https://example\\.com/.* https://subdomain\\.example\\.com/.*",
+      "Enabled": true,
       "InterceptionPoints": {
         "Clipboard": {
-          "Enabled": true | false,
-          "PlainTextOnly": true | false
+          "Enabled": true,
+          "PlainTextOnly": true
         },
         "Download": {
-          "Enabled": false | true,
+          "Enabled": false
         },
         "DragAndDrop": {
-          "Enabled": true | false,
-          "PlainTextOnly": true | false
+          "Enabled": true,
+          "PlainTextOnly": true
         },
         "FileUpload": {
-          "Enabled": true | false
+          "Enabled": true
         },
         "Print": {
-          "Enabled": true | false
+          "Enabled": true
         }
       },
-      "IsPerUser": true | false,
+      "IsPerUser": true,
       "MaxConnectionsCount": 32,
       "PipePathName": "pipe_custom_name",
-      "ShowBlockedResult": true | false,
-      "TimeoutResult": 0 | 1 | 2,
+      "ShowBlockedResult": true,
+      "TimeoutResult": 0
     }
   }
 }


### PR DESCRIPTION
**Description:**

Change the policies JSON regex to be valid.

**Motivation:**

The regex lists were invalid, needing additional escaping for backslashes:

```diff
-      "AllowUrlRegexList": "https://example\.com/.* https://subdomain\.example\.com/.*",
+      "AllowUrlRegexList": "https://example\\.com/.* https://subdomain\\.example\\.com/.*",
```

**Related issues and pull requests:**

Fixes #120
