### PR TITLE
feat: Add DefaultSerialGuardSetting web serial policy

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -70,6 +70,7 @@ unsubmitted
 urlbar
 userprefs
 videocontrols
+webserial
 whattrainisitnow
 Widevine
 xpinstall

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 #### Added
 
-- `DefaultSerialGuardSetting`: Control use of the Web Serial API. ([#](https://github.com/mozilla/enterprise-admin-reference/pull/))
+- `DefaultSerialGuardSetting`: Control use of the Web Serial API. ([#125](https://github.com/mozilla/enterprise-admin-reference/pull/125))
 
 ### esr-153.0.0
 
@@ -30,13 +30,8 @@
 
 ### Added
 
-- `SitePolicies`: Defines policies scoped to specific sites. ([#82](https://github.com/mozilla/enterprise-admin-reference/pull/82))
-
-## fx-150.0.0
-
-### Added
-
 - `LocalNetworkAccess`: Configure local network access security features. ([#67](https://github.com/mozilla/enterprise-admin-reference/pull/67))
+- `SitePolicies`: Defines policies scoped to specific sites. ([#82](https://github.com/mozilla/enterprise-admin-reference/pull/82))
 
 ## fx-149.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ## Unreleased
 
-### fx-150.0.0
+### fx-151.0.0
 
 #### Added
 
-- `SitePolicies`: Defines policies scoped to specific sites. ([#82](https://github.com/mozilla/enterprise-admin-reference/pull/82))
+- `DefaultSerialGuardSetting`: Control use of the Web Serial API. ([#](https://github.com/mozilla/enterprise-admin-reference/pull/))
 
 ### esr-153.0.0
 
@@ -25,6 +25,12 @@
 - `AIControls` policy: Configure AI controls. [#103](https://github.com/mozilla/enterprise-admin-reference/pull/103)
 - `CrashReportsSubmit` policy: Configure crash report submission settings. [#86](https://github.com/mozilla/enterprise-admin-reference/pull/86)
 - `Sync` policy: Enable or disable sync and define which data to include. [#70](https://github.com/mozilla/enterprise-admin-reference/pull/70)
+
+## fx-150.0.0
+
+### Added
+
+- `SitePolicies`: Defines policies scoped to specific sites. ([#82](https://github.com/mozilla/enterprise-admin-reference/pull/82))
 
 ## fx-150.0.0
 

--- a/src/content/docs/reference/policies/DefaultSerialGuardSetting.mdx
+++ b/src/content/docs/reference/policies/DefaultSerialGuardSetting.mdx
@@ -1,0 +1,56 @@
+---
+title: "DefaultSerialGuardSetting"
+description: "Control use of the Web Serial API."
+category: "Content settings"
+---
+
+Control use of the [Web Serial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API).
+
+**Compatibility:** Firefox 151\
+**CCK2 Equivalent:** N/A\
+**Preferences Affected:** `dom.webserial.enabled`
+
+## Values
+
+- `2` means use of the WebSerial API is blocked.
+- `3` means use of the WebSerial API is allowed.
+
+#### Windows (GPO)
+
+```
+Software\Policies\Mozilla\Firefox\DefaultSerialGuardSetting = 0x2 | 0x3
+```
+
+#### Windows (Intune)
+
+OMA-URI:
+
+```url
+./Device/Vendor/MSFT/Policy/Config/Firefox~Policy~firefox/DefaultSerialGuardSetting
+```
+
+Value (string):
+
+```xml
+<enabled/>
+<data id="DefaultSerialGuardSetting" value="2 | 3"/>
+```
+
+#### macOS
+
+```xml
+<dict>
+  <key>DefaultSerialGuardSetting</key>
+  <integer>2 | 3</integer>
+</dict>
+```
+
+#### policies.json
+
+```json
+{
+  "policies": {
+    "DefaultSerialGuardSetting": 2 | 3
+  }
+}
+```


### PR DESCRIPTION
__additions:__
* Adding docs for DefaultSerialGuardSetting.

__changes:__
* Move 150 notes out from unreleased in the changelog

**Motivation:**

DefaultSerialGuardSetting is landing in 151

**Related issues and pull requests:**

- https://github.com/mozilla/policy-templates/pull/1308
- Bugzilla: [Add simple on/off enterprise policy for WebSerial](https://bugzilla.mozilla.org/show_bug.cgi?id=2031173)
