### PR TITLE
fix: make all categories use consistent casing

### DIFF
--- a/src/content/docs/reference/policies/AccessConnector.mdx
+++ b/src/content/docs/reference/policies/AccessConnector.mdx
@@ -1,7 +1,7 @@
 ---
 title: "AccessConnector"
 description: "Configure an Access Connector for proxying web traffic."
-category: "Network Security"
+category: "Network security"
 ---
 
 Configure an Access Connector for proxying web traffic.


### PR DESCRIPTION
**Motivation:**

We have a mix of `Network Security` and `Network security` - we should be consistent.

