### PR TITLE
chore: sync with policy templates repo

### DIFF
--- a/src/content/docs/reference/policies/ContentAnalysis.mdx
+++ b/src/content/docs/reference/policies/ContentAnalysis.mdx
@@ -365,7 +365,7 @@ Value (string):
       "MaxConnectionsCount": 32,
       "PipePathName": "pipe_custom_name",
       "ShowBlockedResult": true | false,
-      "TimeoutResult": 0 | 1 | 2,
+      "TimeoutResult": 0 | 1 | 2
     }
   }
 }

--- a/src/content/docs/reference/policies/Cookies.mdx
+++ b/src/content/docs/reference/policies/Cookies.mdx
@@ -159,7 +159,7 @@ Value (string):
       "Block": ["http://example.edu/"],
       "Locked": true | false,
       "Behavior": "accept" | "reject-foreign" | "reject" | "limit-foreign" | "reject-tracker" | "reject-tracker-and-partition-foreign",
-      "BehaviorPrivateBrowsing": "accept" | "reject-foreign" | "reject" | "limit-foreign" | "reject-tracker" | "reject-tracker-and-partition-foreign",
+      "BehaviorPrivateBrowsing": "accept" | "reject-foreign" | "reject" | "limit-foreign" | "reject-tracker" | "reject-tracker-and-partition-foreign"
     }
   }
 }

--- a/src/content/docs/reference/policies/DNSOverHTTPS.mdx
+++ b/src/content/docs/reference/policies/DNSOverHTTPS.mdx
@@ -124,7 +124,7 @@ Value (string):
       "ProviderURL": "URL_TO_ALTERNATE_PROVIDER",
       "Locked": true | false,
       "ExcludedDomains": ["example.com"],
-      "Fallback": true | false,
+      "Fallback": true | false
     }
   }
 }

--- a/src/content/docs/reference/policies/DisabledCiphers.mdx
+++ b/src/content/docs/reference/policies/DisabledCiphers.mdx
@@ -79,7 +79,7 @@ Value (string):
 {
   "policies": {
     "DisabledCiphers": {
-      "CIPHER_NAME": true | false,
+      "CIPHER_NAME": true | false
     }
   }
 }


### PR DESCRIPTION
**Description:**

Downstreaming https://github.com/mozilla/policy-templates/commit/587570ac6fc679b43a0e4d083918e80f4a00c6f3

**Motivation:**

Some of the pseudocode has trailing commas not caught by linting.

**Related issues and pull requests:**

https://github.com/mozilla/policy-templates/commit/587570ac6fc679b43a0e4d083918e80f4a00c6f3