### PR TITLE
feat: Add note to DefaultSerialGuardSetting policy

### DIFF
--- a/src/content/docs/reference/policies/DefaultSerialGuardSetting.mdx
+++ b/src/content/docs/reference/policies/DefaultSerialGuardSetting.mdx
@@ -6,6 +6,10 @@ category: "Content settings"
 
 Control use of the [Web Serial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API).
 
+> [!NOTE]
+> If any policies are set, the WebSerial API will be blocked by default. To allow usage of the API,
+set this policy to `3`.
+
 **Compatibility:** Firefox 151\
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `dom.webserial.enabled`


### PR DESCRIPTION
* feat: Add note to DefaultSerialGuardSetting policy that WebSerial will be disabled by default if any policies are set.

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
-->

**Description:**

Add note to DefaultSerialGuardSetting policy that WebSerial will be disabled by default if any policies are set.

**Motivation:**

add documentation for this

**Related issues and pull requests:**

Added in Firefox bug 2038282