### PR TITLE
docs: fix "download am extension" typo in ExtensionSettings

### DIFF
--- a/src/content/docs/reference/policies/ExtensionSettings.mdx
+++ b/src/content/docs/reference/policies/ExtensionSettings.mdx
@@ -12,7 +12,7 @@ With an extension ID, the configuration will be applied to the specified extensi
 A default configuration can be set for the special ID `*`, which will apply to all extensions that don't have a custom configuration set in this policy.
 
 To obtain an extension ID, install the extension and go to `about:support`. You will see the ID in the Extensions section.
-You can [download am extension on AMO](https://github.com/mkaply/queryamoid/releases/tag/v0.1) that makes it easy to find the ID of extensions.
+You can [download an extension on AMO](https://github.com/mkaply/queryamoid/releases/tag/v0.1) that makes it easy to find the ID of extensions.
 
 > [!NOTE]
 > If the extension ID is a UUID (e.g., `{12345678-1234-1234-1234-1234567890ab}`), you must include curly braces around the ID.


### PR DESCRIPTION
Fixes #171.

Corrects a small typo in the ExtensionSettings reference page:

> You can [download **am** extension on AMO]…

→

> You can [download **an** extension on AMO]…

Single-word documentation fix.