### PR TITLE
feat: Add weekly cron to fetch upstream schema

### DIFF
--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -1,0 +1,52 @@
+name: Weekly schema sync
+
+on:
+  schedule:
+    # Mondays at 07:00 UTC
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: schema-sync
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Sync schema from upstream
+        run: npm run schema:sync
+
+      # Note this PR won't trigger `./pull-requests.yml` builds yet
+      - name: Open PR on drift
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.9
+        with:
+          branch: automation/schema-sync
+          delete-branch: true
+          commit-message: "chore(schema): sync from upstream"
+          title: "chore(schema): sync from upstream"
+          labels: schema-sync, automated pr
+          body: |
+            Automated weekly sync of `schema/policies-schema.json`.
+
+            Review the diff for new, removed, or changed policies before merging.
+
+            _Opened by the [`.github/workflows/schema-sync.yml`](https://github.com/mozilla/enterprise-admin-reference/tree/main/.github/workflows/schema-sync.yml) workflow._


### PR DESCRIPTION
**Description:**

Add the weekly schema-sync mentioned in #177. The workflow runs `npm run schema:sync` and opens a PR when the upstream schema's drifted.

__Additions:__

* `.github/workflows/schema-sync.yml`: on a cron, plus a manual dispatch

__Known limitation:__

If PRs are opened, they won't yet trigger the `pull-requests.yml` build. This is something for us in a follow-up when we actually consume the schema for something (if and when a new schema could break the build).

__Related issues and pull requests:__

Part of https://github.com/mozilla/enterprise-admin-reference/issues/177
Relates to #178