### PR TITLE
fix: md config passed in via unified

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -16,6 +16,7 @@ cryptomining
 datareporting
 datareporting.healthreport
 Deutsch
+disablepocket
 domainsuffixwhitelist
 domainwhitelist
 Entra

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import starlight from "@astrojs/starlight";
 import starlightGitHubAlerts from "starlight-github-alerts";
 import starlightChangelogs, { makeChangelogsSidebarLinks } from "starlight-changelogs";
 import starlightLinksValidator from "starlight-links-validator";
+import { unified } from "@astrojs/markdown-remark";
 
 export const locales = {
   root: { label: "English", lang: "en" },
@@ -31,7 +32,7 @@ export default defineConfig({
   },
   // Don't render `"` as smart quotes:
   markdown: {
-    smartypants: false,
+    processor: unified({ smartypants: false }),
   },
   integrations: [
     starlight({


### PR DESCRIPTION
**Description:**

Since https://github.com/withastro/astro/releases/tag/astro%406.4.0 there's newer handling for the .md processor.

>The existing top-level markdown.remarkPlugins, markdown.rehypePlugins, markdown.remarkRehype, markdown.gfm, and markdown.smartypants options still work, but are now deprecated and will be removed in a future major update. 

**Motivation:**

Astro shows a warn on builds as this is deprecated.
