### PR TITLE
fix(docs): GFM admonitions broken - remove starlight gh alerts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,6 @@
 // @ts-check
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
-import starlightGitHubAlerts from "starlight-github-alerts";
 import starlightChangelogs, { makeChangelogsSidebarLinks } from "starlight-changelogs";
 import starlightLinksValidator from "starlight-links-validator";
 import { unified } from "@astrojs/markdown-remark";
@@ -58,7 +57,7 @@ export default defineConfig({
       },
       favicon: "/favicon.png",
       lastUpdated: true,
-      plugins: [starlightGitHubAlerts(), starlightChangelogs(), starlightLinksValidator()],
+      plugins: [starlightChangelogs(), starlightLinksValidator()],
       sidebar: [
         {
           label: "Reference",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "astro-breadcrumbs": "^3.4.0",
         "sharp": "^0.35.1",
         "starlight-changelogs": "^0.5.0",
-        "starlight-github-alerts": "^0.2.1",
         "starlight-links-validator": "^0.24.1"
       }
     },
@@ -7876,21 +7875,6 @@
       "peer": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/starlight-github-alerts": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/starlight-github-alerts/-/starlight-github-alerts-0.2.1.tgz",
-      "integrity": "sha512-0iSAx5z6QYZODnaXHyX6eJkOQsqB6PNJL/oC6wUgRQFxgqVnptaf1V4CPTdBJOpYwNh8v/O/bQ0AanPyNBbusw==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      },
-      "peerDependencies": {
-        "@astrojs/starlight": ">=0.38.0"
       }
     },
     "node_modules/starlight-links-validator": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "astro-breadcrumbs": "^3.4.0",
     "sharp": "^0.35.1",
     "starlight-changelogs": "^0.5.0",
-    "starlight-github-alerts": "^0.2.1",
     "starlight-links-validator": "^0.24.1"
   },
   "overrides": {

--- a/src/content/docs/guides/firefox-channels.md
+++ b/src/content/docs/guides/firefox-channels.md
@@ -21,9 +21,10 @@ The following resources are useful for tracking what's changed in Firefox releas
 - [Firefox release notes for developers](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases): these release notes describe **developer-facing** changes.
   This contains details on new or updated web platform features, APIs, and tools that developers use.
 
-> [!NOTE]
-> This release channel is best suited for organizations that want the latest and features as soon as they are available.
-> Because this release channel contains more frequent updates than ESR, UI changes, privacy or security changes may require testing with your environment in a more frequent cadence than the Extended Support Release.
+:::note
+This release channel is best suited for organizations that want the latest and features as soon as they are available.
+Because this release channel contains more frequent updates than ESR, UI changes, privacy or security changes may require testing with your environment in a more frequent cadence than the Extended Support Release.
+:::
 
 ## Firefox Extended Support Release (ESR)
 
@@ -31,10 +32,11 @@ New versions of ESR are released **annually**.
 After release, each ESR version receives incremental security updates as _minor_ or _patch_ release versions (`major.minor.patch`).
 Other features, such as UI or UX improvements, are excluded from the ESR channel, and are limited to annual ESR releases.
 
-> [!NOTE]
-> ESR is ideal for deployment environments that need stability and long-term compatibility.
-> It may be convenient to choose ESR to avoid frequent QA cycles, for example.
-> Other enterprise systems may rely on visual or behavioral consistency during testing or in production environments.
+:::note
+ESR is ideal for deployment environments that need stability and long-term compatibility.
+It may be convenient to choose ESR to avoid frequent QA cycles, for example.
+Other enterprise systems may rely on visual or behavioral consistency during testing or in production environments.
+:::
 
 ## Firefox release schedule
 

--- a/src/content/docs/guides/policies-configuration.mdx
+++ b/src/content/docs/guides/policies-configuration.mdx
@@ -19,8 +19,9 @@ For each operating system, there is a defined location that Firefox will check:
 - **On Linux**, the `policies.json` file goes into `firefox/distribution`, where `firefox` is the installation directory for firefox, which varies by distribution.
   Alternatively, you may specify system-wide policy by placing the file in `/etc/firefox/policies`.
 
-> [!NOTE]
-> The `policies.json` files must be `UTF-8`-encoded.
+:::note
+The `policies.json` files must be `UTF-8`-encoded.
+:::
 
 An example policy looks as follows:
 
@@ -42,8 +43,9 @@ For example, `Authentication_Comment` is an internal value used for documentatio
 }
 ```
 
-> [!WARNING]
-> If you add comments in this way, `about:policies` will display an error due to expected syntax, but the policies will be applied as expected.
+:::caution
+If you add comments in this way, `about:policies` will display an error due to expected syntax, but the policies will be applied as expected.
+:::
 
 ## See also
 

--- a/src/content/docs/reference/policies/AIChatbot.mdx
+++ b/src/content/docs/reference/policies/AIChatbot.mdx
@@ -7,8 +7,9 @@ category: "Content settings"
 Configure the AI chatbot sidebar, including which built-in providers are available and the ability to add custom providers.
 For more information, see [Access AI chatbots in Firefox](https://support.mozilla.org/en-US/kb/ai-chatbot) on support.mozilla.org.
 
-> [!NOTE]
-> Currently, this is only implemented in Firefox Enterprise.
+:::note
+Currently, this is only implemented in Firefox Enterprise.
+:::
 
 **Compatibility:** Firefox Enterprise 149.0.0\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/AccessConnector.mdx
+++ b/src/content/docs/reference/policies/AccessConnector.mdx
@@ -7,8 +7,9 @@ category: "Network security"
 Configure an Access Connector for proxying web traffic.
 When this policy is set, Firefox traffic matching the specified URL patterns is routed through the configured proxy.
 
-> [!NOTE]
-> Currently, this is only implemented in Firefox Enterprise.
+:::note
+Currently, this is only implemented in Firefox Enterprise.
+:::
 
 **Compatibility:** Firefox Enterprise 149.0.0\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/AppUpdatePin.mdx
+++ b/src/content/docs/reference/policies/AppUpdatePin.mdx
@@ -12,8 +12,9 @@ You can specify the major version as `xx.` (e.g, `140.`) and Firefox will be upd
 
 You can specify a major and minor version as `xx.xx.` (e.g, `140.0.`) and Firefox will be updated with all patch versions (`140.0.1`, `140.0.2`), but will not be updated beyond the minor version.
 
-> [!NOTE]
-> The value MUST end in a dot (`.`).
+:::note
+The value MUST end in a dot (`.`).
+:::
 
 You should specify a version that exists or is guaranteed to exist.
 If you specify a version that doesn't exist, Firefox will update beyond that version.

--- a/src/content/docs/reference/policies/BackgroundAppUpdate.mdx
+++ b/src/content/docs/reference/policies/BackgroundAppUpdate.mdx
@@ -13,8 +13,9 @@ If set to `false`, the application will not try to install updates when the appl
 
 If you are having trouble getting the background task to run, verify your configuration with the ["Requirements to run" section in this support document](https://support.mozilla.org/en-US/kb/enable-background-updates-firefox-windows).
 
-> [!NOTE]
-> The `BackgroundAppUpdate` policy has no effect if you have disabled updates via the [`DisableAppUpdate`](/reference/policies/disableappupdate/) policy or disabled automatic updates via the [`AppAutoUpdate`](/reference/policies/appautoupdate/) policy.
+:::note
+The `BackgroundAppUpdate` policy has no effect if you have disabled updates via the [`DisableAppUpdate`](/reference/policies/disableappupdate/) policy or disabled automatic updates via the [`AppAutoUpdate`](/reference/policies/appautoupdate/) policy.
+:::
 
 **Compatibility:** Firefox 90 (Windows only)\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/Bookmarks.mdx
+++ b/src/content/docs/reference/policies/Bookmarks.mdx
@@ -4,9 +4,10 @@ description: "Add bookmarks in either the bookmarks toolbar or menu. Use 'Manage
 category: "Bookmarks"
 ---
 
-> [!WARNING]
-> The [`ManagedBookmarks`](/reference/policies/managedbookmarks/) policy is the recommended way to add bookmarks.
-> The `Bookmarks` policy will continue to be supported for backwards-compatibility purposes.
+:::caution
+The [`ManagedBookmarks`](/reference/policies/managedbookmarks/) policy is the recommended way to add bookmarks.
+The `Bookmarks` policy will continue to be supported for backwards-compatibility purposes.
+:::
 
 Add bookmarks in either the bookmarks toolbar or menu. Only `Title` and `URL` are required. If `Placement` is not specified, the bookmark will be placed on the toolbar. If `Folder` is specified, it is automatically created and bookmarks with the same folder name are grouped together.
 

--- a/src/content/docs/reference/policies/BrowserDataBackup.mdx
+++ b/src/content/docs/reference/policies/BrowserDataBackup.mdx
@@ -7,8 +7,9 @@ category: "Security"
 Disable backup or restore of profile data.
 Backup and restore can be disabled individually.
 
-> [!NOTE]
-> The policy can be used to disable backup and restore if it would otherwise be enabled, but cannot be used to force backup or restore to be enabled under conditions where it would not otherwise be (such as a platform on which backup or restore are not yet supported).
+:::note
+The policy can be used to disable backup and restore if it would otherwise be enabled, but cannot be used to force backup or restore to be enabled under conditions where it would not otherwise be (such as a platform on which backup or restore are not yet supported).
+:::
 
 **Compatibility:** Firefox 146\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/Certificates.mdx
+++ b/src/content/docs/reference/policies/Certificates.mdx
@@ -16,8 +16,10 @@ Install and manage certificates in Firefox.
 
 - `ImportEnterpriseRoots` (boolean): Trust certificates that have been added to the operating system certificate store by a user or administrator.
 
-  > [!NOTE] `ImportEnterpriseRoots` only works on Windows and macOS.
-  > For Linux discussion, see [bug 1600509](https://bugzilla.mozilla.org/show_bug.cgi?id=1600509).
+  :::note
+  `ImportEnterpriseRoots` only works on Windows and macOS.
+  For Linux discussion, see [bug 1600509](https://bugzilla.mozilla.org/show_bug.cgi?id=1600509).
+  :::
 
 - `Install` (array of strings): Install certificates into the Firefox certificate store.
   If only a filename is specified, Firefox searches for the file in the following locations:

--- a/src/content/docs/reference/policies/CrashReportsSubmit.mdx
+++ b/src/content/docs/reference/policies/CrashReportsSubmit.mdx
@@ -9,8 +9,9 @@ Configure crash report submission settings.
 **Compatibility:** Firefox Enterprise 150.0.0\
 **Preferences Affected:** `browser.crashReports.unsubmittedCheck.enabled`, `browser.crashReports.unsubmittedCheck.autoSubmit2`, `browser.tabs.crashReporting.includeURL`, `browser.tabs.crashReporting.sendReport`
 
-> [!NOTE]
-> Currently, this is only implemented in Firefox Enterprise.
+:::note
+Currently, this is only implemented in Firefox Enterprise.
+:::
 
 ## Values
 

--- a/src/content/docs/reference/policies/DefaultSerialGuardSetting.mdx
+++ b/src/content/docs/reference/policies/DefaultSerialGuardSetting.mdx
@@ -6,9 +6,10 @@ category: "Content settings"
 
 Control use of the [Web Serial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API).
 
-> [!NOTE]
-> If any policies are set, the WebSerial API will be blocked by default. To allow usage of the API,
+:::note
+If any policies are set, the WebSerial API will be blocked by default. To allow usage of the API,
 set this policy to `3`.
+:::
 
 **Compatibility:** Firefox 151\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/DisableBuiltinPDFViewer.mdx
+++ b/src/content/docs/reference/policies/DisableBuiltinPDFViewer.mdx
@@ -6,9 +6,11 @@ category: "Printing"
 
 Disable the built in PDF viewer. PDF files are downloaded and sent externally.
 
-> [!NOTE] As of Firefox 140, this policy no longer completely disables PDF.js; it changes the handler to send PDF files to the operating system.
-> Embedded PDF files are shown in the browser.
-> If you need to completely disable PDF.js, you can use the [`PDFjs`](/reference/policies/pdfjs/) policy.
+:::note
+As of Firefox 140, this policy no longer completely disables PDF.js; it changes the handler to send PDF files to the operating system.
+Embedded PDF files are shown in the browser.
+If you need to completely disable PDF.js, you can use the [`PDFjs`](/reference/policies/pdfjs/) policy.
+:::
 
 **Compatibility:** Firefox 60, Firefox ESR 60\
 **CCK2 Equivalent:** `disablePDFjs`\

--- a/src/content/docs/reference/policies/DisabledCiphers.mdx
+++ b/src/content/docs/reference/policies/DisabledCiphers.mdx
@@ -6,10 +6,11 @@ category: "Network security"
 
 Disable specific cryptographic ciphers.
 
-> [!NOTE]
-> This policy was updated in Firefox 78 to allow _enabling_ ciphers as well.
-> Setting a value to `true` disables the cipher, setting a value to `false` enables the cipher.
-> Previously, setting any value (`true` or `false`) disabled the cipher.
+:::note
+This policy was updated in Firefox 78 to allow _enabling_ ciphers as well.
+Setting a value to `true` disables the cipher, setting a value to `false` enables the cipher.
+Previously, setting any value (`true` or `false`) disabled the cipher.
+:::
 
 **Compatibility:** Firefox 76, Firefox ESR 68.8\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/EnableTrackingProtection.mdx
+++ b/src/content/docs/reference/policies/EnableTrackingProtection.mdx
@@ -27,8 +27,9 @@ If this policy is not configured, tracking protection is not enabled by default 
 - If `BaselineExceptions` is true, Firefox will automatically apply exceptions required to avoid major website breakage. (Firefox 145)
 - If `ConvenienceExceptions` is true, Firefox will apply exceptions automatically that are only required to fix minor issues and make convenience features available. (Firefox 145)
 
-> [!NOTE]
-> Users can change `BaselineExceptions` and `ConvenienceExceptions` even when `Category` is set to `strict` unless `Locked` is set to true. If `Locked` is set to `true`, `BaselineExceptions` and `ConvenienceExceptions` use their initial values (based on the tracking protection `Category`) unless policy explicitly sets them.
+:::note
+Users can change `BaselineExceptions` and `ConvenienceExceptions` even when `Category` is set to `strict` unless `Locked` is set to true. If `Locked` is set to `true`, `BaselineExceptions` and `ConvenienceExceptions` use their initial values (based on the tracking protection `Category`) unless policy explicitly sets them.
+:::
 
 ## Windows (GPO)
 

--- a/src/content/docs/reference/policies/ExemptDomainFileTypePairsFromFileTypeDownloadWarnings.mdx
+++ b/src/content/docs/reference/policies/ExemptDomainFileTypePairsFromFileTypeDownloadWarnings.mdx
@@ -7,10 +7,11 @@ category: "Network security"
 Disable warnings based on file extension for specific file types on domains.
 This policy is based on the [Chrome policy](https://chromeenterprise.google/policies/#ExemptDomainFileTypePairsFromFileTypeDownloadWarnings) of the same name.
 
-> [!WARNING]
-> The documentation for the policy for both Edge and Chrome may be inconsistent.
-> The `domains` value must be a domain, not a URL pattern.
-> Additionally, Firefox does not support using a wildcard (`*`) to mean all domains.
+:::caution
+The documentation for the policy for both Edge and Chrome may be inconsistent.
+The `domains` value must be a domain, not a URL pattern.
+Additionally, Firefox does not support using a wildcard (`*`) to mean all domains.
+:::
 
 **Compatibility:** Firefox 102\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/ExtensionSettings.mdx
+++ b/src/content/docs/reference/policies/ExtensionSettings.mdx
@@ -14,8 +14,9 @@ A default configuration can be set for the special ID `*`, which will apply to a
 To obtain an extension ID, install the extension and go to `about:support`. You will see the ID in the Extensions section.
 You can [download an extension on AMO](https://github.com/mkaply/queryamoid/releases/tag/v0.1) that makes it easy to find the ID of extensions.
 
-> [!NOTE]
-> If the extension ID is a UUID (e.g., `{12345678-1234-1234-1234-1234567890ab}`), you must include curly braces around the ID.
+:::note
+If the extension ID is a UUID (e.g., `{12345678-1234-1234-1234-1234567890ab}`), you must include curly braces around the ID.
+:::
 
 **Compatibility:** Firefox 69, Firefox ESR 68.1 (As of Firefox 85, Firefox ESR 78.7, installing a theme makes it the default.)\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/Extensions.mdx
+++ b/src/content/docs/reference/policies/Extensions.mdx
@@ -6,11 +6,12 @@ category: "Extensions"
 
 Control the installation, uninstallation and locking of extensions.
 
-> [!WARNING]
-> The **[`ExtensionSettings`](/reference/policies/extensionsettings/)** policy was added in Firefox 69.
-> It provides additional functionality to `Extensions` and is closer in compatibility to Chrome and Edge.
-> It does not support native paths, so you'll have to use `file://` URLs.
-> Before using `Extensions`, it's recommended to use `ExtensionSettings` as all future improvements will be applied to that policy instead.
+:::caution
+The **[`ExtensionSettings`](/reference/policies/extensionsettings/)** policy was added in Firefox 69.
+It provides additional functionality to `Extensions` and is closer in compatibility to Chrome and Edge.
+It does not support native paths, so you'll have to use `file://` URLs.
+Before using `Extensions`, it's recommended to use `ExtensionSettings` as all future improvements will be applied to that policy instead.
+:::
 
 **Compatibility:** Firefox 60, Firefox ESR 60\
 **CCK2 Equivalent:** `addons`\

--- a/src/content/docs/reference/policies/PDFjs.mdx
+++ b/src/content/docs/reference/policies/PDFjs.mdx
@@ -6,9 +6,10 @@ category: "Printing"
 
 Disable or configure PDF.js, the built-in PDF viewer.
 
-> [!NOTE]
-> DisableBuiltinPDFViewer has not been deprecated. You can either continue to use it, or switch to using `PDFjs->Enabled` to disable the built-in PDF viewer.
-> This new permission was added because we needed a place for `PDFjs->EnabledPermissions`.
+:::note
+DisableBuiltinPDFViewer has not been deprecated. You can either continue to use it, or switch to using `PDFjs->Enabled` to disable the built-in PDF viewer.
+This new permission was added because we needed a place for `PDFjs->EnabledPermissions`.
+:::
 
 **Compatibility:** Firefox 77, Firefox ESR 68.9\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/Preferences.mdx
+++ b/src/content/docs/reference/policies/Preferences.mdx
@@ -10,12 +10,14 @@ Previously you could only set and lock a subset of preferences.
 Starting with Firefox 81 and Firefox ESR 78.3 you can set many more preferences.
 You can also set default preferences, user preferences and you can clear preferences.
 
-> [!NOTE]
-> On Windows, in order to use this policy, you must clear all settings in the old **Preferences (deprecated)** section in group policy.
+:::note
+On Windows, in order to use this policy, you must clear all settings in the old **Preferences (deprecated)** section in group policy.
+:::
 
-> [!NOTE]
-> There are too many preferences to provide comprehensive documentation here.
-> The source file [StaticPrefList.yaml](https://searchfox.org/mozilla-central/source/modules/libpref/init/StaticPrefList.yaml) contains information about most of them.
+:::note
+There are too many preferences to provide comprehensive documentation here.
+The source file [StaticPrefList.yaml](https://searchfox.org/mozilla-central/source/modules/libpref/init/StaticPrefList.yaml) contains information about most of them.
+:::
 
 **Compatibility:** Firefox 81, Firefox ESR 78.3\
 **CCK2 Equivalent:** `preferences`\
@@ -116,8 +118,9 @@ You can also set the `Type` starting in Firefox 123 and Firefox ESR 115.8. It ca
 
 See the examples below for more detail.
 
-> [!WARNING]
-> Make sure you're only setting a particular preference using this mechanism and not some other way.
+:::caution
+Make sure you're only setting a particular preference using this mechanism and not some other way.
+:::
 
 ## Windows (GPO)
 

--- a/src/content/docs/reference/policies/PrivateBrowsingModeAvailability.mdx
+++ b/src/content/docs/reference/policies/PrivateBrowsingModeAvailability.mdx
@@ -8,7 +8,9 @@ Set availability of private browsing mode.
 
 This policy supersedes [`DisablePrivateBrowsing`](/reference/policies/disableprivatebrowsing/)
 
-> [!NOTE] This policy missed Firefox ESR 128.2, but it will be in Firefox ESR 128.3.
+:::note
+This policy missed Firefox ESR 128.2, but it will be in Firefox ESR 128.3.
+:::
 
 **Compatibility:** Firefox 130, Firefox ESR 128.3\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/RequestedLocales.mdx
+++ b/src/content/docs/reference/policies/RequestedLocales.mdx
@@ -7,7 +7,9 @@ category: "Miscellaneous"
 Set the the list of requested locales for the application in order of preference.
 It will cause the corresponding language pack to become active.
 
-> [!NOTE] For Firefox 68, this can now be a string so that you can specify an empty value.
+:::note
+For Firefox 68, this can now be a string so that you can specify an empty value.
+:::
 
 **Compatibility:** Firefox 64, Firefox ESR 60.4, Updated in Firefox 68, Firefox ESR 68\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/SanitizeOnShutdown.mdx
+++ b/src/content/docs/reference/policies/SanitizeOnShutdown.mdx
@@ -8,7 +8,9 @@ Clear local data on shutdown.
 `SanitizeOnShutdown` accepts either a boolean to clear all data types or an object to choose which data types to clear.
 Items that can be selectively deleted include browsing & download history, cookies, active logins, caches, form history, and site preferences.
 
-> [!NOTE] Starting with Firefox 136, `FormData` and `History` are separate data types.
+:::note
+Starting with Firefox 136, `FormData` and `History` are separate data types.
+:::
 
 **Compatibility:** Firefox 60, Firefox ESR 60. Object form added in Firefox 68/ESR 68, `Locked` added in 74/68.6, `History` in Firefox 128.\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/Sync.mdx
+++ b/src/content/docs/reference/policies/Sync.mdx
@@ -6,8 +6,9 @@ category: "Local data storage"
 
 Controls whether [sync](https://www.firefox.com/en-US/features/sync/) should be enabled and which features should be enabled for syncing.
 
-> [!NOTE]
-> Currently, this is only implemented in Firefox Enterprise.
+:::note
+Currently, this is only implemented in Firefox Enterprise.
+:::
 
 **Compatibility:** Firefox Enterprise 150.0.0\
 **CCK2 Equivalent:** N/A\

--- a/src/content/docs/reference/policies/TranslateEnabled.mdx
+++ b/src/content/docs/reference/policies/TranslateEnabled.mdx
@@ -6,7 +6,9 @@ category: "Content settings"
 
 Enable or disable webpage translation.
 
-> [!NOTE] Web page translation is performed entirely client-side, so there is no data or privacy risk transmitting content to a translation service over the network.
+:::note
+Web page translation is performed entirely client-side, so there is no data or privacy risk transmitting content to a translation service over the network.
+:::
 
 If you only want to disable the popup, you can set the `browser.translations.automaticallyPopup` preference to `false` using the [Preferences](/reference/policies/preferences/) policy.
 


### PR DESCRIPTION
**Description:**

`starlight-github-alerts` isn't playing nicely with Astro 6.4+. There's a couple of options, but at the moment, I'm going to revert from the GFM alerts back to  `:::note` syntax. There's a lot of churn, but it's the fastest fix for now.

**Motivation:**

Fixing the admonitions on prod at the moment.

**Related issues and pull requests:**

Fixes #195