### PR TITLE
chore: Expand reference, but collapse policies in sidebar

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -62,8 +62,7 @@ export default defineConfig({
       sidebar: [
         {
           label: "Reference",
-          items: [{ autogenerate: { directory: "reference" } }],
-          collapsed: true,
+          items: [{ autogenerate: { directory: "reference", collapsed: true } }],
         },
         {
           label: "Guides",


### PR DESCRIPTION
**Description:**

This PR expands the reference section, but collapses the policies list to prevent the sidebar from getting too long.

**Motivation:**

Better navigation / exploration.

