### PR TITLE
feat: add schema after examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,17 @@ title: "Some page"
 `PolicyExample` is auto-imported into every page under `src/content/docs/reference/policies`, so there's no need for an `import` line.
 IDEs may flag `PolicyExample` as undefined in the `.mdx` files, but this is safe to ignore.
 
+### Policy schema
+
+`PolicyExample` renders the policy's JSON schema in a collapsible `JSON schema` block directly after the examples.
+The schema is derived from the `schema/policies-schema.json` entry, with the following changes:
+
+- Annotations (`description`, `examples`, and any `x-` prefixed keys) are stripped.
+- `$ref`s (such as `#/definitions/url`) are inlined so the block is self-contained.
+
+Policies absent from `schema/policies-schema.json` render a `Missing schema` message rather than blocking the build.
+See `src/components/PolicySchema.astro` for details.
+
 ## Changelog
 
 The changelog is based on **Firefox versions**, not documentation versions.  

--- a/src/components/PolicyExample.astro
+++ b/src/components/PolicyExample.astro
@@ -1,6 +1,7 @@
 ---
 import { Code } from "@astrojs/starlight/components";
 import schema from "../../schema/policies-schema.json";
+import PolicySchema from "./PolicySchema.astro";
 
 interface Props {
   /** Match a key under `properties` in policies-schema.json. */
@@ -24,3 +25,5 @@ const blocks = examples.map((example) =>
 ---
 
 {blocks.map((code) => <Code code={code} lang="json" title="policies.json" />)}
+
+<PolicySchema policy={policy} />

--- a/src/components/PolicySchema.astro
+++ b/src/components/PolicySchema.astro
@@ -1,0 +1,43 @@
+---
+import { Code } from "@astrojs/starlight/components";
+import schema from "../../schema/policies-schema.json";
+
+interface Props {
+  /** Match a key under `properties` in policies-schema.json. */
+  policy: string;
+}
+
+const { policy } = Astro.props;
+
+const node = (schema.properties as Record<string, unknown>)[policy] ?? {};
+
+// `$ref`s (`#/definitions/{url,origin,urlOrEmpty}`) are inlined so output is self-contained
+const DEFS = "#/definitions/";
+const definitions = (schema as { definitions?: Record<string, unknown> }).definitions ?? {};
+
+// Annotation keys document the policy but aren't part of its validation shape.
+// Dropped at every depth so the block shows just `type`/`enum`/`properties`/etc.
+const isAnnotation = (key: string) =>
+  key === "description" || key === "examples" || key.startsWith("x-");
+
+// As JSON.stringify walks the tree: drop annotation keys and inline each `$ref`.
+const toSchema = (key: string, value: unknown): unknown => {
+  if (isAnnotation(key)) return undefined;
+  const ref = value && typeof value === "object" ? (value as { $ref?: unknown }).$ref : undefined;
+  return typeof ref === "string" && ref.startsWith(DEFS)
+    ? (definitions[ref.slice(DEFS.length)] ?? value)
+    : value;
+};
+
+// An empty node means the policy is absent from policies-schema.json: surface
+// that as the cause rather than rendering a bare `{}`.
+const isEmpty = Object.keys(node as object).length === 0;
+const code = isEmpty
+  ? `Missing schema: "${policy}" is not defined in policies-schema.json`
+  : JSON.stringify(node, toSchema, 2);
+---
+
+<details>
+  <summary>JSON schema</summary>
+  <Code code={code} lang={isEmpty ? "plaintext" : "json"} title={`${policy} JSON schema`} />
+</details>

--- a/src/content/docs/reference/policies/DisablePasswordReveal.mdx
+++ b/src/content/docs/reference/policies/DisablePasswordReveal.mdx
@@ -7,7 +7,7 @@ category: "Password manager"
 Do not allow passwords to be shown in saved logins.
 
 **Compatibility:** Firefox 71, Firefox ESR 68.3\
-**CCK2 Equivalent:** N/A
+**CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 
 ## Examples


### PR DESCRIPTION
**Description:**

Adding a summary / details with the Policy schema after the examples.

**Motivation:**

Addition context on the expected form of the policies.

**Related issues and pull requests:**

- [x] https://github.com/mozilla/enterprise-admin-reference/pull/185