### PR TITLE
chore: Remove special handling of booleans

### DIFF
--- a/src/components/PolicyExample.astro
+++ b/src/components/PolicyExample.astro
@@ -11,12 +11,7 @@ interface Props {
 const { policy } = Astro.props;
 
 const entry = (schema.properties as Record<string, { examples?: unknown[] }>)[policy];
-const allExamples = Array.isArray(entry?.examples) ? entry.examples : [];
-
-// Only show one scalar-valued example (boolean)
-const isScalar = (value: unknown) => value === null || typeof value !== "object";
-const examples =
-  allExamples.length > 1 && allExamples.every(isScalar) ? allExamples.slice(0, 1) : allExamples;
+const examples = Array.isArray(entry?.examples) ? entry.examples : [];
 
 // Wrap each in `{ policies: { policyname:`, so it's copy-paste ready.
 const blocks = examples.map((example) =>


### PR DESCRIPTION
**Description:**

Remove special handling of boolean examples.

**Motivation:**

When adding support for rendering examples from the schema, we hid some of the booleans because it wasn't looking so nice. We can revert back now after the following changes:

- [x] [[Bug 2059681] Boolean examples should show one useful value](https://bugzilla.mozilla.org/show_bug.cgi?id=2059681)

**Related issues and pull requests:**

- [x] https://github.com/mozilla/enterprise-admin-reference/pull/185