### PR TITLE
feat: Add CNSA2KeyAgreementEnabled policy

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -12,6 +12,8 @@ browser.newtabpage.activity-stream.asrouter
 browser.safebrowsing
 CHACHA
 chatbots
+cloudsecurityalliance
+CNSA
 cryptomining
 datareporting
 datareporting.healthreport
@@ -38,6 +40,8 @@ localfilelinks
 managedfirefox
 mathml
 menupanel
+middlebox
+mlkem
 msword
 network.dns.echconfig
 newtab
@@ -73,6 +77,7 @@ unsubmitted
 urlbar
 userprefs
 videocontrols
+webrtc
 webserial
 whattrainisitnow
 Widevine

--- a/src/content/docs/reference/policies/CNSA2KeyAgreementEnabled.mdx
+++ b/src/content/docs/reference/policies/CNSA2KeyAgreementEnabled.mdx
@@ -1,0 +1,55 @@
+---
+title: "CNSA2KeyAgreementEnabled"
+description: "Enable the CNSA 2.0 ML-KEM-1024 key agreement for TLS."
+category: "Network security"
+---
+
+Enables the CNSA 2.0 [ML-KEM-1024](https://www.ietf.org/archive/id/draft-ietf-tls-mlkem-02.html) key agreement for TLS.
+
+ML-KEM-1024 is the highest-strength parameter of the post-quantum key encapsulation mechanism specified in [FIPS 203](https://csrc.nist.gov/pubs/fips/203/final), and the algorithm required by version 2.0 of the Commercial National Security Algorithm Suite (CNSA).
+When the policy is set to `true`, Firefox offers the ML-KEM-1024 key agreement group during the TLS handshake.
+ML-KEM-1024 is not offered by default.
+
+Setting this policy locks the preference, whether the value is `true` or `false`, so users cannot change it.
+
+**Compatibility:** Firefox 154\
+**CCK2 Equivalent:** N/A\
+**Preferences Affected:** `security.tls.enable_mlkem1024`
+
+## Examples
+
+<PolicyExample policy="CNSA2KeyAgreementEnabled" />
+
+## Windows (GPO)
+
+```
+Software\Policies\Mozilla\Firefox\CNSA2KeyAgreementEnabled = 0x1 | 0x0
+```
+
+## Windows (Intune)
+
+OMA-URI:
+
+```url
+./Device/Vendor/MSFT/Policy/Config/Firefox~Policy~firefox/CNSA2KeyAgreementEnabled
+```
+
+Value (string):
+
+```xml
+<enabled/> or <disabled/>
+```
+
+## macOS
+
+```xml
+<dict>
+  <key>CNSA2KeyAgreementEnabled</key>
+  <true/> | <false/>
+</dict>
+```
+
+## See also
+
+- [`PostQuantumKeyAgreementEnabled`](/reference/policies/postquantumkeyagreementenabled/) policy, which controls the ML-KEM-768 key agreement offered to general web traffic.
+- [NIST FIPS 203, 204, and 205 Finalized: An Important Step Towards a Quantum-Safe Future](https://cloudsecurityalliance.org/blog/2024/08/15/nist-fips-203-204-and-205-finalized-an-important-step-towards-a-quantum-safe-future) on cloudsecurityalliance.org (2024)

--- a/src/content/docs/reference/policies/PostQuantumKeyAgreementEnabled.mdx
+++ b/src/content/docs/reference/policies/PostQuantumKeyAgreementEnabled.mdx
@@ -6,9 +6,19 @@ category: "Network security"
 
 Enable post-quantum key agreement for TLS.
 
+Firefox offers hybrid [X25519](https://en.wikipedia.org/wiki/Curve25519) + [ML-KEM-768](https://csrc.nist.gov/pubs/fips/203/final) key agreement by default, so most deployments do not need this policy.
+The policy covers TLS, HTTP/3 as of Firefox 128, and WebRTC.
+
+> [!WARNING]
+> Disabling post-quantum key agreement removes protection against later decryption of recorded traffic.
+> Only set this policy to `false` as a temporary workaround if there are cases of failure, such as a middlebox, proxy, or legacy server that cannot handle the ClientHello.
+
+Setting this policy locks the preferences, whether the value is `true` or `false`, so users cannot change them.
+This policy is independent of [`CNSA2KeyAgreementEnabled`](/reference/policies/cnsa2keyagreementenabled/): setting it to `false` does not stop Firefox from offering ML-KEM-1024 if that policy is enabled.
+
 **Compatibility:** Firefox 127\
 **CCK2 Equivalent:** N/A\
-**Preferences Affected:** `security.tls.enable_kyber`, `network.http.http3.enable_kyber` (Firefox 128)
+**Preferences Affected:** `security.tls.enable_kyber`, `network.http.http3.enable_kyber` (Firefox 128), `media.webrtc.enable_pq_hybrid_kex`
 
 ## Examples
 
@@ -42,3 +52,7 @@ Value (string):
   <true/> | <false/>
 </dict>
 ```
+
+## See also
+
+- [`CNSA2KeyAgreementEnabled`](/reference/policies/cnsa2keyagreementenabled/) policy, which controls the CNSA 2.0 ML-KEM-1024 key agreement for TLS.


### PR DESCRIPTION
**Description:**

Documenting the CNSA2KeyAgreementEnabled policy and adding some details and xrefs to PostQuantumKeyAgreementEnabled, which is similar, but distinct.

__Additions:__

- New page for CNSA2KeyAgreementEnabled

__Changes:__

- PostQuantumKeyAgreementEnabled has more information disambiguating the two policies

Resources:

- [Add a pref and enterprise policy to enable CNSA2.0 key agreement](https://bugzilla.mozilla.org/show_bug.cgi?id=2052296)
- [Add a policy for Kyber](https://bugzilla.mozilla.org/show_bug.cgi?id=1894068)
  - https://chromeenterprise.google/policies/#PostQuantumKeyAgreementEnabled
  - https://learn.microsoft.com/en-us/deployedge/microsoft-edge-policies#postquantumkeyagreementenabled

**Related issues and pull requests:**

Fixes https://github.com/mozilla/enterprise-admin-reference/issues/262