### PR TITLE
feat: Add DefaultBrowserSettingEnabled policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+- `DefaultBrowserSettingEnabled` policy: Control whether the user can set Firefox as the default browser.
 - `DisableLocalPolicies` policy: Disable all local policy sources (policies.json, Windows GPO and macOS plist). [#216](https://github.com/mozilla/enterprise-admin-reference/pull/216)
 
 ### Changed

--- a/src/content/docs/reference/policies/DefaultBrowserSettingEnabled.mdx
+++ b/src/content/docs/reference/policies/DefaultBrowserSettingEnabled.mdx
@@ -1,0 +1,54 @@
+---
+title: "DefaultBrowserSettingEnabled"
+description: "Control whether the user can set Firefox as the default browser."
+category: "Startup"
+---
+
+Control whether the user can set Firefox as the default browser.
+
+When the policy is set to `false`, the default browser check is disabled and the controls for setting Firefox as the default browser are removed from the preferences.
+When it is set to `true`, the default browser check runs at startup and users cannot turn it off.
+
+To suppress the startup check without removing the controls from browser preferences, use the [`DontCheckDefaultBrowser`](/reference/policies/dontcheckdefaultbrowser/) policy instead.
+
+**Compatibility:** Firefox 154\
+**CCK2 Equivalent:** N/A\
+**Preferences Affected:** `browser.shell.checkDefaultBrowser`
+
+## Examples
+
+<PolicyExample policy="DefaultBrowserSettingEnabled" />
+
+## Windows (GPO)
+
+```
+Software\Policies\Mozilla\Firefox\DefaultBrowserSettingEnabled = 0x1 | 0x0
+```
+
+## Windows (Intune)
+
+OMA-URI:
+
+```url
+./Device/Vendor/MSFT/Policy/Config/Firefox~Policy~firefox/DefaultBrowserSettingEnabled
+```
+
+Value (string):
+
+```xml
+<enabled/> or <disabled/>
+```
+
+## macOS
+
+```xml
+<dict>
+  <key>DefaultBrowserSettingEnabled</key>
+  <true/> | <false/>
+</dict>
+```
+
+## See also
+
+- [`DisableDefaultBrowserAgent`](/reference/policies/disabledefaultbrowseragent/) policy
+- [`DontCheckDefaultBrowser`](/reference/policies/dontcheckdefaultbrowser/) policy

--- a/src/content/docs/reference/policies/DisableDefaultBrowserAgent.mdx
+++ b/src/content/docs/reference/policies/DisableDefaultBrowserAgent.mdx
@@ -40,4 +40,6 @@ Value (string):
 
 ## See also
 
+- [`DefaultBrowserSettingEnabled`](/reference/policies/defaultbrowsersettingenabled/) policy
+- [`DontCheckDefaultBrowser`](/reference/policies/dontcheckdefaultbrowser/) policy
 - [Default Browser Agent](https://firefox-source-docs.mozilla.org/toolkit/mozapps/defaultagent/default-browser-agent/index.html) on firefox-source-docs.mozilla.org

--- a/src/content/docs/reference/policies/DontCheckDefaultBrowser.mdx
+++ b/src/content/docs/reference/policies/DontCheckDefaultBrowser.mdx
@@ -6,6 +6,11 @@ category: "Startup"
 
 Don't check if Firefox is the default browser at startup.
 
+When set to `true`, the startup check is skipped, but users can still set Firefox as the default in the preferences.
+The preference is locked in both cases, so users cannot change whether the check runs.
+
+To remove the controls to set Firefox as the default browser, see the [`DefaultBrowserSettingEnabled`](/reference/policies/defaultbrowsersettingenabled/) policy instead.
+
 **Compatibility:** Firefox 60, Firefox ESR 60\
 **CCK2 Equivalent:** `dontCheckDefaultBrowser`\
 **Preferences Affected:** `browser.shell.checkDefaultBrowser`
@@ -42,3 +47,8 @@ Value (string):
   <true/> | <false/>
 </dict>
 ```
+
+## See also
+
+- [`DefaultBrowserSettingEnabled`](/reference/policies/defaultbrowsersettingenabled/) policy
+- [`DisableDefaultBrowserAgent`](/reference/policies/disabledefaultbrowseragent/) policy


### PR DESCRIPTION

**Description:**

__Additions:__

- New page for DefaultBrowserSettingEnabled, landing in 154

__Changes:__

- Add xrefs to/from DisableDefaultBrowserAgent
- cross-link and add context in DontCheckDefaultBrowser, showing relation between both policies

**Motivation:**

We have a new policy landing in 154, this adds some docs for it. 

**Related issues and pull requests:**

Fixes #263