### PR TITLE
chore: use PolicyCompat component instead of prose [a-d]

### DIFF
--- a/src/content/docs/reference/policies/3rdparty.mdx
+++ b/src/content/docs/reference/policies/3rdparty.mdx
@@ -8,7 +8,10 @@ Allow WebExtensions to configure policies.
 For more information, see [Adding policy support to your extension](https://extensionworkshop.com/documentation/enterprise/enterprise-development/#how-to-add-policy).
 For GPO and Intune, the extension developer should provide an ADMX file.
 
-**Compatibility:** Firefox 68\
+## Compatibility
+
+<PolicyCompat policy="3rdparty" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/AIControls.mdx
+++ b/src/content/docs/reference/policies/AIControls.mdx
@@ -7,7 +7,10 @@ category: "Miscellaneous"
 Configure AI controls.
 For more information, see [Block generative AI features with Firefox AI controls](https://support.mozilla.org/en-US/kb/firefox-ai-controls) on support.mozilla.org.
 
-**Compatibility:** Firefox Enterprise 149.0.0\
+## Compatibility
+
+<PolicyCompat policy="AIControls" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.ml.chat.enabled`, `browser.ml.chat.page`, `browser.ai.control.sidebarChatbot`, `browser.translations.enable`, `browser.ai.control.translations`, `pdfjs.enableAltText`, `browser.ai.control.pdfjsAltText`, `browser.ml.linkPreview.enabled`, `browser.ai.control.linkPreviewKeyPoints`, `browser.tabs.groups.smart.userEnabled`, `browser.ai.control.smartTabGroups`, `browser.ai.control.smartWindow`
 

--- a/src/content/docs/reference/policies/AllowFileSelectionDialogs.mdx
+++ b/src/content/docs/reference/policies/AllowFileSelectionDialogs.mdx
@@ -6,7 +6,10 @@ category: "Browser UI"
 
 Enable or disable file selection dialogs.
 
-**Compatibility:** Firefox 124\
+## Compatibility
+
+<PolicyCompat policy="AllowFileSelectionDialogs" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `widget.disable_file_pickers`
 

--- a/src/content/docs/reference/policies/AllowedDomainsForApps.mdx
+++ b/src/content/docs/reference/policies/AllowedDomainsForApps.mdx
@@ -8,7 +8,10 @@ Define domains allowed to access Google Workspace.
 This policy is based on the [Chrome policy](https://chromeenterprise.google/policies/#AllowedDomainsForApps) of the same name.
 If this policy is enabled, users can only access Google Workspace using accounts from the specified domains. If you want to allow Gmail, you can add `consumer_accounts` to the list.
 
-**Compatibility:** Firefox 89, Firefox ESR 78.11\
+## Compatibility
+
+<PolicyCompat policy="AllowedDomainsForApps" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/AppAutoUpdate.mdx
+++ b/src/content/docs/reference/policies/AppAutoUpdate.mdx
@@ -12,7 +12,10 @@ If set to `false`, application updates are downloaded but the user can choose wh
 
 If you have disabled updates via [`DisableAppUpdate`](/reference/policies/disableappupdate/), this policy has no effect.
 
-**Compatibility:** Firefox 75, Firefox ESR 68.7\
+## Compatibility
+
+<PolicyCompat policy="AppAutoUpdate" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `app.update.auto`
 

--- a/src/content/docs/reference/policies/AppUpdatePin.mdx
+++ b/src/content/docs/reference/policies/AppUpdatePin.mdx
@@ -18,7 +18,10 @@ You can specify a major and minor version as `xx.xx.` (e.g, `140.0.`) and Firefo
 You should specify a version that exists or is guaranteed to exist.
 If you specify a version that doesn't exist, Firefox will update beyond that version.
 
-**Compatibility:** Firefox 102,\
+## Compatibility
+
+<PolicyCompat policy="AppUpdatePin" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/AppUpdateURL.mdx
+++ b/src/content/docs/reference/policies/AppUpdateURL.mdx
@@ -6,7 +6,10 @@ category: "Device update settings"
 
 Change the URL for application update if you are providing Firefox updates from a custom update server.
 
-**Compatibility:** Firefox 62, Firefox ESR 60.2\
+## Compatibility
+
+<PolicyCompat policy="AppUpdateURL" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `app.update.url`
 

--- a/src/content/docs/reference/policies/Authentication.mdx
+++ b/src/content/docs/reference/policies/Authentication.mdx
@@ -9,7 +9,12 @@ See [Integrated authentication](https://htmlpreview.github.io/?https://github.co
 
 The `PrivateBrowsing` member enables integrated authentication in private browsing.
 
-**Compatibility:** Firefox 60, Firefox ESR 60 (`AllowNonFQDN` added in 62/60.2, `AllowProxies` added in 70/68.2, `Locked` added in 71/68.3, `PrivateBrowsing` added in 77/68.9)\
+## Compatibility
+
+<PolicyCompat policy="Authentication" />
+
+`AllowNonFQDN` added in 62/60.2, `AllowProxies` added in 70/68.2, `Locked` added in 71/68.3, `PrivateBrowsing` added in 77/68.9.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.negotiate-auth.trusted-uris`,`network.negotiate-auth.delegation-uris`,`network.automatic-ntlm-auth.trusted-uris`,`network.automatic-ntlm-auth.allow-non-fqdn`,`network.negotiate-auth.allow-non-fqdn`,`network.automatic-ntlm-auth.allow-proxies`,`network.negotiate-auth.allow-proxies`,`network.auth.private-browsing-sso`
 

--- a/src/content/docs/reference/policies/AutoLaunchProtocolsFromOrigins.mdx
+++ b/src/content/docs/reference/policies/AutoLaunchProtocolsFromOrigins.mdx
@@ -9,7 +9,10 @@ Define a list of external protocols that can be used from listed origins without
 The syntax of this policy is exactly the same as the [Chrome AutoLaunchProtocolsFromOrigins policy](https://chromeenterprise.google/policies/#AutoLaunchProtocolsFromOrigins) except that you can only use valid origins (not just hostnames).
 This also means that you cannot specify a wildcard (`*`) for all origins.
 
-**Compatibility:** Firefox 90, Firefox ESR 78.12\
+## Compatibility
+
+<PolicyCompat policy="AutoLaunchProtocolsFromOrigins" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/AutofillAddressEnabled.mdx
+++ b/src/content/docs/reference/policies/AutofillAddressEnabled.mdx
@@ -9,7 +9,10 @@ Enables or disables autofill for addresses.
 This only applies when address autofill is enabled for a particular Firefox version or region.
 See [Automatically fill in your address on web forms](https://support.mozilla.org/kb/automatically-fill-your-address-web-forms) for more information.
 
-**Compatibility:** Firefox 125, Firefox ESR 115.10\
+## Compatibility
+
+<PolicyCompat policy="AutofillAddressEnabled" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `extensions.formautofill.addresses.enabled`
 

--- a/src/content/docs/reference/policies/AutofillCreditCardEnabled.mdx
+++ b/src/content/docs/reference/policies/AutofillCreditCardEnabled.mdx
@@ -8,7 +8,10 @@ Enables or disables autofill for payment methods.
 
 This only applies when payment method autofill is enabled for a particular Firefox version or region. See [Automatically fill in credit card data](https://support.mozilla.org/kb/credit-card-autofill) for more information.
 
-**Compatibility:** Firefox 125, Firefox ESR 115.10\
+## Compatibility
+
+<PolicyCompat policy="AutofillCreditCardEnabled" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `extensions.formautofill.creditCards.enabled`
 

--- a/src/content/docs/reference/policies/BackgroundAppUpdate.mdx
+++ b/src/content/docs/reference/policies/BackgroundAppUpdate.mdx
@@ -16,7 +16,12 @@ If you are having trouble getting the background task to run, verify your config
 > [!NOTE]
 > The `BackgroundAppUpdate` policy has no effect if you have disabled updates via the [`DisableAppUpdate`](/reference/policies/disableappupdate/) policy or disabled automatic updates via the [`AppAutoUpdate`](/reference/policies/appautoupdate/) policy.
 
-**Compatibility:** Firefox 90 (Windows only)\
+## Compatibility
+
+<PolicyCompat policy="BackgroundAppUpdate" />
+
+Windows only.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `app.update.background.enabled`
 

--- a/src/content/docs/reference/policies/BlockAboutAddons.mdx
+++ b/src/content/docs/reference/policies/BlockAboutAddons.mdx
@@ -6,7 +6,10 @@ category: "Extensions"
 
 Block access to the Add-ons Manager (`about:addons`).
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="BlockAboutAddons" />
+
 **CCK2 Equivalent:** `disableAddonsManager`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/BlockAboutConfig.mdx
+++ b/src/content/docs/reference/policies/BlockAboutConfig.mdx
@@ -6,7 +6,10 @@ category: "Security"
 
 Block access to `about:config`.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="BlockAboutConfig" />
+
 **CCK2 Equivalent:** `disableAboutConfig`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/BlockAboutProfiles.mdx
+++ b/src/content/docs/reference/policies/BlockAboutProfiles.mdx
@@ -6,7 +6,10 @@ category: "Security"
 
 Block access to About Profiles (`about:profiles`).
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="BlockAboutProfiles" />
+
 **CCK2 Equivalent:** `disableAboutProfiles`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/BlockAboutSupport.mdx
+++ b/src/content/docs/reference/policies/BlockAboutSupport.mdx
@@ -6,7 +6,10 @@ category: "Security"
 
 Block access to Troubleshooting Information (`about:support`).
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="BlockAboutSupport" />
+
 **CCK2 Equivalent:** `disableAboutSupport`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/Bookmarks.mdx
+++ b/src/content/docs/reference/policies/Bookmarks.mdx
@@ -12,7 +12,10 @@ Add bookmarks in either the bookmarks toolbar or menu. Only `Title` and `URL` ar
 
 If you want to clear all bookmarks set with this policy, you can set the value to an empty array (`[]`). This can be on Windows via the new Bookmarks (JSON) policy available with GPO and Intune.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="Bookmarks" />
+
 **CCK2 Equivalent:** `bookmarks.toolbar`,`bookmarks.menu`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/BrowserDataBackup.mdx
+++ b/src/content/docs/reference/policies/BrowserDataBackup.mdx
@@ -10,7 +10,10 @@ Backup and restore can be disabled individually.
 > [!NOTE]
 > The policy can be used to disable backup and restore if it would otherwise be enabled, but cannot be used to force backup or restore to be enabled under conditions where it would not otherwise be (such as a platform on which backup or restore are not yet supported).
 
-**Compatibility:** Firefox 146\
+## Compatibility
+
+<PolicyCompat policy="BrowserDataBackup" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/CNSA2KeyAgreementEnabled.mdx
+++ b/src/content/docs/reference/policies/CNSA2KeyAgreementEnabled.mdx
@@ -12,7 +12,10 @@ ML-KEM-1024 is not offered by default.
 
 Setting this policy locks the preference, whether the value is `true` or `false`, so users cannot change it.
 
-**Compatibility:** Firefox 154\
+## Compatibility
+
+<PolicyCompat policy="CNSA2KeyAgreementEnabled" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `security.tls.enable_mlkem1024`
 

--- a/src/content/docs/reference/policies/CaptivePortal.mdx
+++ b/src/content/docs/reference/policies/CaptivePortal.mdx
@@ -6,7 +6,10 @@ category: "Network security"
 
 Enable or disable the detection of captive portals.
 
-**Compatibility:** Firefox 67, Firefox ESR 60.7\
+## Compatibility
+
+<PolicyCompat policy="CaptivePortal" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.captive-portal-service.enabled`
 

--- a/src/content/docs/reference/policies/Certificates.mdx
+++ b/src/content/docs/reference/policies/Certificates.mdx
@@ -6,7 +6,12 @@ category: "Certificate management"
 
 Install and manage certificates in Firefox.
 
-**Compatibility:** Firefox 60, Firefox ESR 60. `ImportEnterpriseRoots` macOS support added in Firefox 63/ESR 68, `Install` added in Firefox 64/ESR 64\
+## Compatibility
+
+<PolicyCompat policy="Certificates" />
+
+`ImportEnterpriseRoots` macOS support added in Firefox 63/ESR 68, `Install` added in Firefox 64/ESR 64.
+
 **CCK2 Equivalent:** `certs.ca` (Install)\
 **Preferences Affected:** `security.enterprise_roots.enabled`
 

--- a/src/content/docs/reference/policies/Containers.mdx
+++ b/src/content/docs/reference/policies/Containers.mdx
@@ -6,7 +6,10 @@ category: "Extensions"
 
 Set policies related to [Multi-Account Containers](https://addons.mozilla.org/firefox/addon/multi-account-containers/).
 
-**Compatibility:** Firefox 113\
+## Compatibility
+
+<PolicyCompat policy="Containers" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/ContentAnalysis.mdx
+++ b/src/content/docs/reference/policies/ContentAnalysis.mdx
@@ -6,7 +6,10 @@ category: "Cloud reporting"
 
 Configure Firefox to use an agent for Data Loss Prevention (DLP) that is compatible with the [Google Chrome Content Analysis Connector Agent SDK](https://github.com/chromium/content_analysis_sdk).
 
-**Compatibility:** Firefox 137\
+## Compatibility
+
+<PolicyCompat policy="ContentAnalysis" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.contentanalysis.agent_name`, `browser.contentanalysis.agent_timeout`, `browser.contentanalysis.allow_url_regex_list`, `browser.contentanalysis.bypass_for_same_tab_operations`, `browser.contentanalysis.client_signature`, `browser.contentanalysis.default_result`, `browser.contentanalysis.deny_url_regex_list`, `browser.contentanalysis.enabled`, `browser.contentanalysis.interception_point.clipboard.enabled`, `browser.contentanalysis.interception_point.clipboard.plain_text_only`, `browser.contentanalysis.interception_point.download.enabled`, `browser.contentanalysis.interception_point.drag_and_drop.enabled`, `browser.contentanalysis.interception_point.drag_and_drop.plain_text_only`, `browser.contentanalysis.interception_point.file_upload.enabled`, `browser.contentanalysis.interception_point.print.enabled`, `browser.contentanalysis.is_per_user`, `browser.contentanalysis.max_connections`, `browser.contentanalysis.pipe_path_name`, `browser.contentanalysis.show_blocked_result`, `browser.contentanalysis.timeout_result`
 

--- a/src/content/docs/reference/policies/Cookies.mdx
+++ b/src/content/docs/reference/policies/Cookies.mdx
@@ -6,7 +6,12 @@ category: "Network security"
 
 Configure cookie preferences.
 
-**Compatibility:** Firefox 60, Firefox ESR 60 (RejectTracker added in Firefox 63, AllowSession added in Firefox 79/78.1, Behavior added in Firefox 95/91.4, reject-tracker-and-partition-foreign renamed to partition-foreign in Firefox 153)\
+## Compatibility
+
+<PolicyCompat policy="Cookies" />
+
+`RejectTracker` added in Firefox 63, `AllowSession` added in Firefox 79/78.1, `q` added in Firefox 95/91.4, `reject-tracker-and-partition-foreign` renamed to `partition-foreign` in Firefox 153.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.cookie.cookieBehavior`, `network.cookie.cookieBehavior.pbmode`, `network.cookie.lifetimePolicy`
 

--- a/src/content/docs/reference/policies/DefaultDownloadDirectory.mdx
+++ b/src/content/docs/reference/policies/DefaultDownloadDirectory.mdx
@@ -8,7 +8,10 @@ Set the default download directory.
 
 You can use `${home}` for the native home directory.
 
-**Compatibility:** Firefox 68, Firefox ESR 68\
+## Compatibility
+
+<PolicyCompat policy="DefaultDownloadDirectory" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.download.dir`, `browser.download.folderList`
 

--- a/src/content/docs/reference/policies/DefaultSerialGuardSetting.mdx
+++ b/src/content/docs/reference/policies/DefaultSerialGuardSetting.mdx
@@ -10,7 +10,10 @@ Control use of the [Web Serial API](https://developer.mozilla.org/en-US/docs/Web
 > If any enterprise policies are set, the WebSerial API is blocked by default.
 > To allow usage of the API, set this policy to `3`.
 
-**Compatibility:** Firefox 151\
+## Compatibility
+
+<PolicyCompat policy="DefaultSerialGuardSetting" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `dom.webserial.enabled`
 

--- a/src/content/docs/reference/policies/DisableAccounts.mdx
+++ b/src/content/docs/reference/policies/DisableAccounts.mdx
@@ -6,7 +6,10 @@ category: "Miscellaneous"
 
 Disable account-based services, including sync.
 
-**Compatibility:** Firefox 119\
+## Compatibility
+
+<PolicyCompat policy="DisableAccounts" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisableAppUpdate.mdx
+++ b/src/content/docs/reference/policies/DisableAppUpdate.mdx
@@ -6,7 +6,10 @@ category: "Device update settings"
 
 Turn off application updates within Firefox.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableAppUpdate" />
+
 **CCK2 Equivalent:** `disableFirefoxUpdates`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisableBuiltinPDFViewer.mdx
+++ b/src/content/docs/reference/policies/DisableBuiltinPDFViewer.mdx
@@ -10,7 +10,10 @@ Disable the built in PDF viewer. PDF files are downloaded and sent externally.
 > Embedded PDF files are shown in the browser.
 > If you need to completely disable PDF.js, you can use the [`PDFjs`](/reference/policies/pdfjs/) policy.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableBuiltinPDFViewer" />
+
 **CCK2 Equivalent:** `disablePDFjs`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisableDefaultBrowserAgent.mdx
+++ b/src/content/docs/reference/policies/DisableDefaultBrowserAgent.mdx
@@ -10,7 +10,12 @@ Only applicable to Windows; other platforms don't have the agent.
 The browser agent is a Windows-only scheduled task which runs in the background to collect and submit data about the browser that the user has set as their OS default.
 More information is available in the [Default Browser Agent](https://firefox-source-docs.mozilla.org/toolkit/mozapps/defaultagent/default-browser-agent/index.html) article.
 
-**Compatibility:** Firefox 75, Firefox ESR 68.7 (Windows only)\
+## Compatibility
+
+<PolicyCompat policy="DisableDefaultBrowserAgent" />
+
+Windows only.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisableDeveloperTools.mdx
+++ b/src/content/docs/reference/policies/DisableDeveloperTools.mdx
@@ -6,7 +6,10 @@ category: "Security"
 
 Remove access to all developer tools.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableDeveloperTools" />
+
 **CCK2 Equivalent:** `removeDeveloperTools`\
 **Preferences Affected:** `devtools.policy.disabled`
 

--- a/src/content/docs/reference/policies/DisableEncryptedClientHello.mdx
+++ b/src/content/docs/reference/policies/DisableEncryptedClientHello.mdx
@@ -7,7 +7,10 @@ category: "Network security"
 Disable the TLS Feature for Encrypted Client Hello.
 Note that TLS Client Hellos will still contain an ECH extension, but this extension will not be used by Firefox during the TLS handshake.
 
-**Compatibility:** Firefox 127, Firefox ESR 128\
+## Compatibility
+
+<PolicyCompat policy="DisableEncryptedClientHello" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.dns.echconfig.enabled`, `network.dns.http3_echconfig.enabled`
 

--- a/src/content/docs/reference/policies/DisableFeedbackCommands.mdx
+++ b/src/content/docs/reference/policies/DisableFeedbackCommands.mdx
@@ -6,7 +6,10 @@ category: "Browser UI"
 
 Disable the menus for reporting sites (Submit Feedback, Report Deceptive Site).
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableFeedbackCommands" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisableFirefoxAccounts.mdx
+++ b/src/content/docs/reference/policies/DisableFirefoxAccounts.mdx
@@ -6,7 +6,10 @@ category: "Miscellaneous"
 
 Disable Firefox Accounts integration (Sync).
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableFirefoxAccounts" />
+
 **CCK2 Equivalent:** `disableSync`\
 **Preferences Affected:** `identity.fxaccounts.enabled`
 

--- a/src/content/docs/reference/policies/DisableFirefoxScreenshots.mdx
+++ b/src/content/docs/reference/policies/DisableFirefoxScreenshots.mdx
@@ -6,7 +6,10 @@ category: "Miscellaneous"
 
 Remove access to Firefox Screenshots.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableFirefoxScreenshots" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `extensions.screenshots.disabled`
 

--- a/src/content/docs/reference/policies/DisableFirefoxStudies.mdx
+++ b/src/content/docs/reference/policies/DisableFirefoxStudies.mdx
@@ -6,7 +6,10 @@ category: "Miscellaneous"
 
 Disable Firefox studies (Shield).
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableFirefoxStudies" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons`, `browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features`
 

--- a/src/content/docs/reference/policies/DisabledCiphers.mdx
+++ b/src/content/docs/reference/policies/DisabledCiphers.mdx
@@ -11,7 +11,10 @@ Disable specific cryptographic ciphers.
 > Setting a value to `true` disables the cipher, setting a value to `false` enables the cipher.
 > Previously, setting any value (`true` or `false`) disabled the cipher.
 
-**Compatibility:** Firefox 76, Firefox ESR 68.8\
+## Compatibility
+
+<PolicyCompat policy="DisabledCiphers" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `security.ssl3.ecdhe_rsa_aes_128_gcm_sha256`, `security.ssl3.ecdhe_ecdsa_aes_128_gcm_sha256`, `security.ssl3.ecdhe_ecdsa_chacha20_poly1305_sha256`, `security.ssl3.ecdhe_rsa_chacha20_poly1305_sha256`, `security.ssl3.ecdhe_ecdsa_aes_256_gcm_sha384`, `security.ssl3.ecdhe_rsa_aes_256_gcm_sha384`, `security.ssl3.ecdhe_rsa_aes_128_sha`, `security.ssl3.ecdhe_ecdsa_aes_128_sha`, `security.ssl3.ecdhe_rsa_aes_256_sha`, `security.ssl3.ecdhe_ecdsa_aes_256_sha`, `security.ssl3.dhe_rsa_aes_128_sha`, `security.ssl3.dhe_rsa_aes_256_sha`, `security.ssl3.rsa_aes_128_gcm_sha256`, `security.ssl3.rsa_aes_256_gcm_sha384`, `security.ssl3.rsa_aes_128_sha`, `security.ssl3.rsa_aes_256_sha`, `security.ssl3.deprecated.rsa_des_ede3_sha`, `security.tls13.chacha20_poly1305_sha256`, `security.tls13.aes_128_gcm_sha256`, `security.tls13.aes_256_gcm_sha384`
 


### PR DESCRIPTION

**Description:**

Swap out the compat info from prose to the schema.

I'm adding a H2 and replacing the content so it's at the top, although in future, we may want to move the compat info down to the bottom of the page. This is for ease of reviews at this stage.

**Motivation:**

The compat info is now tracked via schema. We can pull this in programmatically instead of in prose.

**Related issues and pull requests:**

- [x] github.com/mozilla/enterprise-admin-reference/pull/269