### PR TITLE
chore: use PolicyCompat component instead of prose [d-p]

### DIFF
--- a/src/content/docs/reference/policies/DNSOverHTTPS.mdx
+++ b/src/content/docs/reference/policies/DNSOverHTTPS.mdx
@@ -6,7 +6,12 @@ category: "Network security"
 
 Configure DNS over HTTPS.
 
-**Compatibility:** Firefox 63, Firefox ESR 68 (ExcludedDomains added in 75/68.7) (Fallback added in 124)\
+## Compatibility
+
+<PolicyCompat policy="DNSOverHTTPS" />
+
+`ExcludedDomains` added in 75/68.7, `Fallback` added in 124.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.trr.mode`, `network.trr.uri`
 

--- a/src/content/docs/reference/policies/DisableForgetButton.mdx
+++ b/src/content/docs/reference/policies/DisableForgetButton.mdx
@@ -6,7 +6,10 @@ category: "Miscellaneous"
 
 Disable the "Forget" button.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableForgetButton" />
+
 **CCK2 Equivalent:** `disableForget`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisableFormHistory.mdx
+++ b/src/content/docs/reference/policies/DisableFormHistory.mdx
@@ -6,7 +6,10 @@ category: "Local data storage"
 
 Turn off saving information on web forms and the search bar.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableFormHistory" />
+
 **CCK2 Equivalent:** `disableFormFill`\
 **Preferences Affected:** `browser.formfill.enable`
 

--- a/src/content/docs/reference/policies/DisableMasterPasswordCreation.mdx
+++ b/src/content/docs/reference/policies/DisableMasterPasswordCreation.mdx
@@ -10,7 +10,10 @@ If this value is `true`, it works the same as setting [`PrimaryPassword`](/refer
 
 If both `DisableMasterPasswordCreation` and [`PrimaryPassword`](/reference/policies/primarypassword/) are used, `DisableMasterPasswordCreation` takes precedence.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableMasterPasswordCreation" />
+
 **CCK2 Equivalent:** `noMasterPassword`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisablePasswordReveal.mdx
+++ b/src/content/docs/reference/policies/DisablePasswordReveal.mdx
@@ -6,7 +6,10 @@ category: "Password manager"
 
 Do not allow passwords to be shown in saved logins.
 
-**Compatibility:** Firefox 71, Firefox ESR 68.3\
+## Compatibility
+
+<PolicyCompat policy="DisablePasswordReveal" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisablePocket.mdx
+++ b/src/content/docs/reference/policies/DisablePocket.mdx
@@ -6,7 +6,10 @@ category: "Miscellaneous"
 
 Remove Pocket in the Firefox UI. It does not remove it from the new tab page.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisablePocket" />
+
 **CCK2 Equivalent:** `disablePocket`\
 **Preferences Affected:** `extensions.pocket.enabled`
 

--- a/src/content/docs/reference/policies/DisablePrivateBrowsing.mdx
+++ b/src/content/docs/reference/policies/DisablePrivateBrowsing.mdx
@@ -8,7 +8,10 @@ Remove access to private browsing.
 
 This policy is superseded by the [`PrivateBrowsingModeAvailability`](/reference/policies/privatebrowsingmodeavailability/) policy.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisablePrivateBrowsing" />
+
 **CCK2 Equivalent:** `disablePrivateBrowsing`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisableProfileImport.mdx
+++ b/src/content/docs/reference/policies/DisableProfileImport.mdx
@@ -6,7 +6,10 @@ category: "Bookmarks"
 
 Remove the ability to import data from other browsers.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableProfileImport" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisableProfileRefresh.mdx
+++ b/src/content/docs/reference/policies/DisableProfileRefresh.mdx
@@ -6,7 +6,10 @@ category: "Miscellaneous"
 
 Disable the Refresh Firefox button on `about:support` and `support.mozilla.org`, as well as the prompt that displays offering to refresh Firefox when you haven't used it in a while.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableProfileRefresh" />
+
 **CCK2 Equivalent:** `disableResetFirefox`\
 **Preferences Affected:** `browser.disableResetPrompt`
 

--- a/src/content/docs/reference/policies/DisableRemoteImprovements.mdx
+++ b/src/content/docs/reference/policies/DisableRemoteImprovements.mdx
@@ -6,7 +6,10 @@ category: "Miscellaneous"
 
 Prevent Firefox from applying performance, stability, and feature changes between updates.
 
-**Compatibility:** Firefox 148\
+## Compatibility
+
+<PolicyCompat policy="DisableRemoteImprovements" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisableRemoteSettingsAndAcceptSecurityConsequences.mdx
+++ b/src/content/docs/reference/policies/DisableRemoteSettingsAndAcceptSecurityConsequences.mdx
@@ -11,7 +11,10 @@ Remote Settings is the mechanism Firefox uses to deliver frequently updated data
 > [!WARNING]
 > Turning off Remote Settings stops Firefox from receiving security-critical updates such as the add-on blocklist. Only enable this policy if you fully understand and accept the security consequences.
 
-**Compatibility:** Firefox 153\
+## Compatibility
+
+<PolicyCompat policy="DisableRemoteSettingsAndAcceptSecurityConsequences" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisableSafeMode.mdx
+++ b/src/content/docs/reference/policies/DisableSafeMode.mdx
@@ -8,7 +8,12 @@ Disable safe mode ([Troubleshoot Mode](https://support.mozilla.org/en-US/kb/diag
 
 On Windows, this disables safe mode via the command line as well.
 
-**Compatibility:** Firefox 60, Firefox ESR 60 (Windows, macOS)\
+## Compatibility
+
+<PolicyCompat policy="DisableSafeMode" />
+
+Windows and macOS only.
+
 **CCK2 Equivalent:** `disableSafeMode`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisableSecurityBypass.mdx
+++ b/src/content/docs/reference/policies/DisableSecurityBypass.mdx
@@ -8,7 +8,10 @@ Prevent the user from bypassing security in certain cases.
 
 These policies only affect what happens when an error is shown, they do not affect any settings in preferences.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableSecurityBypass" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `security.certerror.hideAddException`, `browser.safebrowsing.allowOverride`
 

--- a/src/content/docs/reference/policies/DisableSetDesktopBackground.mdx
+++ b/src/content/docs/reference/policies/DisableSetDesktopBackground.mdx
@@ -6,7 +6,10 @@ category: "Browser UI"
 
 Remove the "Set As Desktop Background..." menuitem when right clicking on an image.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableSetDesktopBackground" />
+
 **CCK2 Equivalent:** `removeSetDesktopBackground`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisableSystemAddonUpdate.mdx
+++ b/src/content/docs/reference/policies/DisableSystemAddonUpdate.mdx
@@ -6,7 +6,10 @@ category: "Device update settings"
 
 Prevent system add-ons from being installed or updated.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableSystemAddonUpdate" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisableTelemetry.mdx
+++ b/src/content/docs/reference/policies/DisableTelemetry.mdx
@@ -11,7 +11,10 @@ As of Firefox 83 and Firefox ESR 78.5, local storage of telemetry data is disabl
 Mozilla recommends that you do not disable telemetry.
 Information collected through telemetry helps us build a better product for businesses like yours.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DisableTelemetry" />
+
 **CCK2 Equivalent:** `disableTelemetry`\
 **Preferences Affected:** `datareporting.healthreport.uploadEnabled`, `datareporting.policy.dataSubmissionEnabled`, `toolkit.telemetry.archive.enabled`, `datareporting.usage.uploadEnabled`
 

--- a/src/content/docs/reference/policies/DisableThirdPartyModuleBlocking.mdx
+++ b/src/content/docs/reference/policies/DisableThirdPartyModuleBlocking.mdx
@@ -8,7 +8,12 @@ Do not allow blocking third-party modules (DLLs) from the `about:third-party` pa
 
 This policy only works on Windows through GPO, not via `policies.json`.
 
-**Compatibility:** Firefox 110 (Windows only, GPO only)\
+## Compatibility
+
+<PolicyCompat policy="DisableThirdPartyModuleBlocking" />
+
+Windows only, GPO only.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisplayBookmarksToolbar.mdx
+++ b/src/content/docs/reference/policies/DisplayBookmarksToolbar.mdx
@@ -6,7 +6,12 @@ category: "Bookmarks"
 
 Set the initial state of the bookmarks toolbar. A user can still change how it is displayed.
 
-**Compatibility:** Firefox 109, Firefox ESR 102.7\
+## Compatibility
+
+<PolicyCompat policy="DisplayBookmarksToolbar" />
+
+The string values below were added in Firefox 108, Firefox ESR 102.7. Earlier versions accept only `true` or `false`.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DisplayMenuBar.mdx
+++ b/src/content/docs/reference/policies/DisplayMenuBar.mdx
@@ -6,7 +6,14 @@ category: "Browser UI"
 
 Set the state of the menubar.
 
-**Compatibility:** Firefox 73, Firefox ESR 68.5 (Windows, some Linux)\
+## Compatibility
+
+<PolicyCompat policy="DisplayMenuBar" />
+
+Windows and some Linux only.
+
+The string values below were added in Firefox 72, Firefox ESR 68.5. Earlier versions accept only `true` or `false`.
+
 **CCK2 Equivalent:** `displayMenuBar`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/DontCheckDefaultBrowser.mdx
+++ b/src/content/docs/reference/policies/DontCheckDefaultBrowser.mdx
@@ -11,7 +11,10 @@ The preference is locked in both cases, so users cannot change whether the check
 
 To remove the controls to set Firefox as the default browser, see the [`DefaultBrowserSettingEnabled`](/reference/policies/defaultbrowsersettingenabled/) policy instead.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="DontCheckDefaultBrowser" />
+
 **CCK2 Equivalent:** `dontCheckDefaultBrowser`\
 **Preferences Affected:** `browser.shell.checkDefaultBrowser`
 

--- a/src/content/docs/reference/policies/DownloadDirectory.mdx
+++ b/src/content/docs/reference/policies/DownloadDirectory.mdx
@@ -7,7 +7,10 @@ category: "Downloads"
 Set and lock the download directory.
 You can use `${home}` for the native home directory.
 
-**Compatibility:** Firefox 68, Firefox ESR 68\
+## Compatibility
+
+<PolicyCompat policy="DownloadDirectory" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.download.dir`, `browser.download.folderList`, `browser.download.useDownloadDir`
 

--- a/src/content/docs/reference/policies/EnableTrackingProtection.mdx
+++ b/src/content/docs/reference/policies/EnableTrackingProtection.mdx
@@ -8,7 +8,12 @@ Configure tracking protection.
 
 If this policy is not configured, tracking protection is not enabled by default in the browser, but it is enabled by default in private browsing and the user can change it.
 
-**Compatibility:** Firefox 60, Firefox ESR 60 (Cryptomining and Fingerprinting added in 70/68.2, Exceptions added in 73/68.5. Category added in Firefox 142/140.2.)\
+## Compatibility
+
+<PolicyCompat policy="EnableTrackingProtection" />
+
+`Cryptomining` and `Fingerprinting` added in 70/68.2, `Exceptions` added in 73/68.5, `Category` added in Firefox 142/140.2.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `privacy.trackingprotection.enabled`, `privacy.trackingprotection.pbmode.enabled`, `privacy.trackingprotection.cryptomining.enabled`, `privacy.trackingprotection.fingerprinting.enabled`, `privacy.fingerprintingProtection`, `privacy.trackingprotection.emailtracking.enabled`, `privacy.trackingprotection.emailtracking.pbmode.enabled`, `privacy.trackingprotection.allow_list.baseline.enabled`, `privacy.trackingprotection.allow_list.convenience.enabled`
 

--- a/src/content/docs/reference/policies/EncryptedMediaExtensions.mdx
+++ b/src/content/docs/reference/policies/EncryptedMediaExtensions.mdx
@@ -6,7 +6,10 @@ category: "Content settings"
 
 Enable or disable Encrypted Media Extensions and optionally lock it.
 
-**Compatibility:** Firefox 77, Firefox ESR 68.9\
+## Compatibility
+
+<PolicyCompat policy="EncryptedMediaExtensions" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `media.eme.enabled`
 

--- a/src/content/docs/reference/policies/ExemptDomainFileTypePairsFromFileTypeDownloadWarnings.mdx
+++ b/src/content/docs/reference/policies/ExemptDomainFileTypePairsFromFileTypeDownloadWarnings.mdx
@@ -12,7 +12,10 @@ This policy is based on the [Chrome policy](https://chromeenterprise.google/poli
 > The `domains` value must be a domain, not a URL pattern.
 > Additionally, Firefox does not support using a wildcard (`*`) to mean all domains.
 
-**Compatibility:** Firefox 102\
+## Compatibility
+
+<PolicyCompat policy="ExemptDomainFileTypePairsFromFileTypeDownloadWarnings" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/ExtensionSettings.mdx
+++ b/src/content/docs/reference/policies/ExtensionSettings.mdx
@@ -17,7 +17,12 @@ For locally-installed extensions, go to `about:support` and in the "Add-ons" sec
 > [!NOTE]
 > If the extension ID is a UUID (e.g., `{12345678-1234-1234-1234-1234567890ab}`), you must include curly braces around the ID.
 
-**Compatibility:** Firefox 69, Firefox ESR 68.1 (As of Firefox 85, Firefox ESR 78.7, installing a theme makes it the default.)\
+## Compatibility
+
+<PolicyCompat policy="ExtensionSettings" />
+
+As of Firefox 85, Firefox ESR 78.7, installing a theme makes it the default.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/ExtensionUpdate.mdx
+++ b/src/content/docs/reference/policies/ExtensionUpdate.mdx
@@ -6,7 +6,10 @@ category: "Extensions"
 
 Control extension updates.
 
-**Compatibility:** Firefox 67, Firefox ESR 60.7\
+## Compatibility
+
+<PolicyCompat policy="ExtensionUpdate" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `extensions.update.enabled`
 

--- a/src/content/docs/reference/policies/Extensions.mdx
+++ b/src/content/docs/reference/policies/Extensions.mdx
@@ -12,7 +12,10 @@ Control the installation, uninstallation and locking of extensions.
 > It does not support native paths, so you'll have to use `file://` URLs.
 > Before using `Extensions`, it's recommended to use `ExtensionSettings` as all future improvements will be applied to that policy instead.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="Extensions" />
+
 **CCK2 Equivalent:** `addons`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/FirefoxHome.mdx
+++ b/src/content/docs/reference/policies/FirefoxHome.mdx
@@ -6,7 +6,12 @@ category: "Startup"
 
 Customize the Firefox Home page.
 
-**Compatibility:** Firefox 68, Firefox ESR 68 (`SponsoredTopSites` and `SponsoredPocket` were added in Firefox 95, Firefox ESR 91.4, Snippets was deprecated in Firefox 122, Stories and SponsoredStories were added in Firefox 141 to replace Pocket and SponsoredPocket, Weather was added in Firefox 152, Firefox ESR 140.12.)\
+## Compatibility
+
+<PolicyCompat policy="FirefoxHome" />
+
+`SponsoredTopSites` and `SponsoredPocket` were added in Firefox 95, Firefox ESR 91.4, `Snippets` was deprecated in Firefox 122, `Stories` and `SponsoredStories` were added in Firefox 141 to replace `Pocket` and `SponsoredPocket`, `Weather` was added in Firefox 152, Firefox ESR 140.12.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.newtabpage.activity-stream.showSearch`, `browser.newtabpage.activity-stream.feeds.topsites`, `browser.newtabpage.activity-stream.feeds.section.highlights`, `browser.newtabpage.activity-stream.feeds.section.topstories`, `browser.newtabpage.activity-stream.feeds.snippets`, `browser.newtabpage.activity-stream.showSponsoredTopSites`, `browser.newtabpage.activity-stream.showSponsored`, `browser.newtabpage.activity-stream.showWeather`
 

--- a/src/content/docs/reference/policies/FirefoxSuggest.mdx
+++ b/src/content/docs/reference/policies/FirefoxSuggest.mdx
@@ -7,7 +7,10 @@ category: "Search"
 Customize Firefox Suggest (US only).
 As of Firefox 146, `WebSuggestions` turns off Suggest completely.
 
-**Compatibility:** Firefox 118, Firefox ESR 115.3.\
+## Compatibility
+
+<PolicyCompat policy="FirefoxSuggest" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.urlbar.suggest.quicksuggest.all`, `browser.urlbar.suggest.quicksuggest.sponsored`, `browser.urlbar.quicksuggest.dataCollection.enabled`
 

--- a/src/content/docs/reference/policies/GenerativeAI.mdx
+++ b/src/content/docs/reference/policies/GenerativeAI.mdx
@@ -6,7 +6,10 @@ category: "Miscellaneous"
 
 Configure generative AI features.
 
-**Compatibility:** Firefox 144, Firefox ESR 140.4\
+## Compatibility
+
+<PolicyCompat policy="GenerativeAI" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.ml.chat.enabled`, `browser.ml.chat.page`, `browser.ml.linkPreview.optin`, `browser.tabs.groups.smart.userEnabled`
 

--- a/src/content/docs/reference/policies/GoToIntranetSiteForSingleWordEntryInAddressBar.mdx
+++ b/src/content/docs/reference/policies/GoToIntranetSiteForSingleWordEntryInAddressBar.mdx
@@ -6,7 +6,10 @@ category: "Network security"
 
 Whether to always go through the DNS server before sending a single word search string to a search engine.
 
-**Compatibility:** Firefox 104, Firefox ESR 102.2\
+## Compatibility
+
+<PolicyCompat policy="GoToIntranetSiteForSingleWordEntryInAddressBar" />
+
 **CCK2 Equivalent:** `N/A`\
 **Preferences Affected:** `browser.fixup.dns_first_for_single_words`
 

--- a/src/content/docs/reference/policies/Handlers.mdx
+++ b/src/content/docs/reference/policies/Handlers.mdx
@@ -8,7 +8,10 @@ This policy is based on the internal format of `handlers.json`.
 
 You can configure handlers based on a [mime type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types) (`mimeTypes`), a file's extension (`extensions`), or a [protocol](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes) (`schemes`).
 
-**Compatibility:** Firefox 78, Firefox ESR 78\
+## Compatibility
+
+<PolicyCompat policy="Handlers" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/HardwareAcceleration.mdx
+++ b/src/content/docs/reference/policies/HardwareAcceleration.mdx
@@ -6,7 +6,10 @@ category: "Miscellaneous"
 
 Control hardware acceleration.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="HardwareAcceleration" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `layers.acceleration.disabled`
 

--- a/src/content/docs/reference/policies/Homepage.mdx
+++ b/src/content/docs/reference/policies/Homepage.mdx
@@ -6,7 +6,12 @@ category: "Startup"
 
 Configure the default homepage and how Firefox starts.
 
-**Compatibility:** Firefox 60, Firefox ESR 60 (StartPage was added in Firefox 60, Firefox ESR 60.4, homepage-locked added in Firefox 78, NewTabOnRestore added in Firefox 154)\
+## Compatibility
+
+<PolicyCompat policy="Homepage" />
+
+`StartPage` was added in Firefox 60, Firefox ESR 60.4, `homepage-locked` added in Firefox 78, `NewTabOnRestore` added in Firefox 154.
+
 **CCK2 Equivalent:** `homePage`,`lockHomePage`\
 **Preferences Affected:** `browser.startup.homepage`, `browser.startup.page`, `browser.sessionstore.newTabOnRestore`, `browser.sessionstore.newTabOnRestore.showSetting`
 

--- a/src/content/docs/reference/policies/HttpAllowlist.mdx
+++ b/src/content/docs/reference/policies/HttpAllowlist.mdx
@@ -7,7 +7,10 @@ category: "Network security"
 Configure sites that will not be upgraded to HTTPS.
 The sites are specified as a list of origins.
 
-**Compatibility:** Firefox 127\
+## Compatibility
+
+<PolicyCompat policy="HttpAllowlist" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/HttpsOnlyMode.mdx
+++ b/src/content/docs/reference/policies/HttpsOnlyMode.mdx
@@ -6,7 +6,10 @@ category: "Network security"
 
 Configure HTTPS-Only Mode.
 
-**Compatibility:** Firefox 127\
+## Compatibility
+
+<PolicyCompat policy="HttpsOnlyMode" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `dom.security.https_only_mode`
 

--- a/src/content/docs/reference/policies/IPProtectionAvailable.mdx
+++ b/src/content/docs/reference/policies/IPProtectionAvailable.mdx
@@ -6,7 +6,10 @@ category: "Network security"
 
 Prevent the built-in VPN from being available to users.
 
-**Compatibility:** Firefox 149\
+## Compatibility
+
+<PolicyCompat policy="IPProtectionAvailable" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.ipProtection.enabled`
 

--- a/src/content/docs/reference/policies/InstallAddonsPermission.mdx
+++ b/src/content/docs/reference/policies/InstallAddonsPermission.mdx
@@ -6,7 +6,10 @@ category: "Extensions"
 
 Configure the default extension install policy as well as origins for extension installs are allowed. This policy does not override turning off all extension installs.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="InstallAddonsPermission" />
+
 **CCK2 Equivalent:** `permissions.install`\
 **Preferences Affected:** `xpinstall.enabled`, `browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons`, `browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features`
 

--- a/src/content/docs/reference/policies/LegacyProfiles.mdx
+++ b/src/content/docs/reference/policies/LegacyProfiles.mdx
@@ -12,7 +12,12 @@ If this policy set to `false`, Firefox will create a new profile for each unique
 
 This policy only work on Windows via GPO (not via `policies.json`).
 
-**Compatibility:** Firefox 70, Firefox ESR 68.2 (Windows only, GPO only)\
+## Compatibility
+
+<PolicyCompat policy="LegacyProfiles" />
+
+Windows only, GPO only.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/LegacySameSiteCookieBehaviorEnabled.mdx
+++ b/src/content/docs/reference/policies/LegacySameSiteCookieBehaviorEnabled.mdx
@@ -8,7 +8,10 @@ Enable default legacy SameSite cookie behavior setting.
 
 If this policy is set to true, it reverts all cookies to legacy SameSite behavior which means that cookies that don't explicitly specify a [`SameSite` attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) are treated as if they were `SameSite=None`.
 
-**Compatibility:** Firefox 96\
+## Compatibility
+
+<PolicyCompat policy="LegacySameSiteCookieBehaviorEnabled" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.cookie.sameSite.laxByDefault`
 

--- a/src/content/docs/reference/policies/LegacySameSiteCookieBehaviorEnabledForDomainList.mdx
+++ b/src/content/docs/reference/policies/LegacySameSiteCookieBehaviorEnabledForDomainList.mdx
@@ -8,7 +8,10 @@ Revert to legacy SameSite behavior for cookies on specified sites.
 
 If this policy is set to true, cookies set for domains in this list will revert to legacy SameSite behavior which means that cookies that don't explicitly specify a [`SameSite` attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) are treated as if they were `SameSite=None`.
 
-**Compatibility:** Firefox 96\
+## Compatibility
+
+<PolicyCompat policy="LegacySameSiteCookieBehaviorEnabledForDomainList" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.cookie.sameSite.laxByDefault.disabledHosts`
 

--- a/src/content/docs/reference/policies/LocalFileLinks.mdx
+++ b/src/content/docs/reference/policies/LocalFileLinks.mdx
@@ -6,7 +6,10 @@ category: "Network security"
 
 Enable linking to local files by origin.
 
-**Compatibility:** Firefox 68, Firefox ESR 68\
+## Compatibility
+
+<PolicyCompat policy="LocalFileLinks" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `capability.policy.localfilelinks.*`
 

--- a/src/content/docs/reference/policies/LocalNetworkAccess.mdx
+++ b/src/content/docs/reference/policies/LocalNetworkAccess.mdx
@@ -7,7 +7,10 @@ category: "Network security"
 Configure local network access security features.
 The `LocalNetworkAccess` policy controls Firefox's behavior when websites attempt to access local network resources (localhost and local network addresses).
 
-**Compatibility:** Firefox 150\
+## Compatibility
+
+<PolicyCompat policy="LocalNetworkAccess" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.lna.enabled`, `network.lna.block_trackers`, `network.lna.blocking`, `network.lna.skip-domains`
 

--- a/src/content/docs/reference/policies/ManagedBookmarks.mdx
+++ b/src/content/docs/reference/policies/ManagedBookmarks.mdx
@@ -14,7 +14,10 @@ A `favicon` can be specified for each bookmark. The value must be a `data:`, `ht
 
 A bookmark's `url` can be a `javascript:` URL to create a bookmarklet. (Firefox 153)
 
-**Compatibility:** Firefox 83, Firefox ESR 78.5\
+## Compatibility
+
+<PolicyCompat policy="ManagedBookmarks" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/ManualAppUpdateOnly.mdx
+++ b/src/content/docs/reference/policies/ManualAppUpdateOnly.mdx
@@ -14,7 +14,10 @@ If this policy is enabled:
 
 This policy is primarily intended for advanced end users, not for enterprises, but it is available via GPO.
 
-**Compatibility:** Firefox 87\
+## Compatibility
+
+<PolicyCompat policy="ManualAppUpdateOnly" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/MicrosoftEntraSSO.mdx
+++ b/src/content/docs/reference/policies/MicrosoftEntraSSO.mdx
@@ -8,7 +8,10 @@ Allow single sign-on for Microsoft Entra accounts on macOS.
 
 If this policy is set to `true`, Firefox will use credentials stored in the Company Portal to sign in to Microsoft Entra accounts.
 
-**Compatibility:** Firefox 132.0.1, Firefox ESR 128.5\
+## Compatibility
+
+<PolicyCompat policy="MicrosoftEntraSSO" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.http.microsoft-entra-sso.enabled`
 

--- a/src/content/docs/reference/policies/NetworkPrediction.mdx
+++ b/src/content/docs/reference/policies/NetworkPrediction.mdx
@@ -6,7 +6,10 @@ category: "Network security"
 
 Enable or disable network prediction ([DNS prefetching](https://developer.mozilla.org/en-US/docs/Glossary/Prefetch#dns_prefetching)).
 
-**Compatibility:** Firefox 67, Firefox ESR 60.7\
+## Compatibility
+
+<PolicyCompat policy="NetworkPrediction" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.dns.disablePrefetch`, `network.dns.disablePrefetchFromHTTPS`
 

--- a/src/content/docs/reference/policies/NewTabPage.mdx
+++ b/src/content/docs/reference/policies/NewTabPage.mdx
@@ -6,7 +6,10 @@ category: "Startup"
 
 Enable or disable the New Tab page.
 
-**Compatibility:** Firefox 68, Firefox ESR 68\
+## Compatibility
+
+<PolicyCompat policy="NewTabPage" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.newtabpage.enabled`
 

--- a/src/content/docs/reference/policies/NoDefaultBookmarks.mdx
+++ b/src/content/docs/reference/policies/NoDefaultBookmarks.mdx
@@ -8,7 +8,10 @@ Disable the creation of default bookmarks.
 
 This policy is only effective if the user profile has not been created yet.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="NoDefaultBookmarks" />
+
 **CCK2 Equivalent:** `removeDefaultBookmarks`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/OfferToSaveLogins.mdx
+++ b/src/content/docs/reference/policies/OfferToSaveLogins.mdx
@@ -6,7 +6,10 @@ category: "Password manager"
 
 Control whether or not Firefox offers to save passwords.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="OfferToSaveLogins" />
+
 **CCK2 Equivalent:** `dontRememberPasswords`\
 **Preferences Affected:** `signon.rememberSignons`
 

--- a/src/content/docs/reference/policies/OfferToSaveLoginsDefault.mdx
+++ b/src/content/docs/reference/policies/OfferToSaveLoginsDefault.mdx
@@ -6,7 +6,10 @@ category: "Password manager"
 
 Sets the default value of `signon.rememberSignons` without locking it.
 
-**Compatibility:** Firefox 70, Firefox ESR 60.2\
+## Compatibility
+
+<PolicyCompat policy="OfferToSaveLoginsDefault" />
+
 **CCK2 Equivalent:** `dontRememberPasswords`\
 **Preferences Affected:** `signon.rememberSignons`
 

--- a/src/content/docs/reference/policies/OverrideFirstRunPage.mdx
+++ b/src/content/docs/reference/policies/OverrideFirstRunPage.mdx
@@ -8,7 +8,10 @@ Override the first run page. If the value is an empty string (`""`), the first r
 
 Starting with Firefox 83, Firefox ESR 78.5, you can also specify multiple URLs separated by a vertical bar (`|`).
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="OverrideFirstRunPage" />
+
 **CCK2 Equivalent:** `welcomePage`,`noWelcomePage`\
 **Preferences Affected:** `startup.homepage_welcome_url`
 

--- a/src/content/docs/reference/policies/OverridePostUpdatePage.mdx
+++ b/src/content/docs/reference/policies/OverridePostUpdatePage.mdx
@@ -6,7 +6,10 @@ category: "Startup"
 
 Override the upgrade page. If the value is an empty string (`""`), no extra pages are displayed when Firefox is upgraded.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="OverridePostUpdatePage" />
+
 **CCK2 Equivalent:** `upgradePage`,`noUpgradePage`\
 **Preferences Affected:** `startup.homepage_override_url`
 

--- a/src/content/docs/reference/policies/PDFjs.mdx
+++ b/src/content/docs/reference/policies/PDFjs.mdx
@@ -10,7 +10,10 @@ Disable or configure PDF.js, the built-in PDF viewer.
 > DisableBuiltinPDFViewer has not been deprecated. You can either continue to use it, or switch to using `PDFjs->Enabled` to disable the built-in PDF viewer.
 > This new permission was added because we needed a place for `PDFjs->EnabledPermissions`.
 
-**Compatibility:** Firefox 77, Firefox ESR 68.9\
+## Compatibility
+
+<PolicyCompat policy="PDFjs" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `pdfjs.disabled`, `pdfjs.enablePermissions`
 

--- a/src/content/docs/reference/policies/PasswordManagerEnabled.mdx
+++ b/src/content/docs/reference/policies/PasswordManagerEnabled.mdx
@@ -6,7 +6,10 @@ category: "Password manager"
 
 Remove access to the password manager via preferences and blocks about:logins on Firefox 70.
 
-**Compatibility:** Firefox 70, Firefox ESR 60.2\
+## Compatibility
+
+<PolicyCompat policy="PasswordManagerEnabled" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `pref.privacy.disable_button.view_passwords`, `signon.rememberSignons`
 

--- a/src/content/docs/reference/policies/PasswordManagerExceptions.mdx
+++ b/src/content/docs/reference/policies/PasswordManagerExceptions.mdx
@@ -8,7 +8,10 @@ Prevent Firefox from saving passwords for specific sites.
 
 The sites are specified as a list of origins.
 
-**Compatibility:** Firefox 101\
+## Compatibility
+
+<PolicyCompat policy="PasswordManagerExceptions" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/Permissions.mdx
+++ b/src/content/docs/reference/policies/Permissions.mdx
@@ -8,7 +8,12 @@ Set permissions associated with camera, microphone, location, notifications, aut
 Because these are origins, not domains, entries with unique ports must be specified separately.
 This explicitly means that it is not possible to add wildcards. See examples below.
 
-**Compatibility:** Firefox 62, Firefox ESR 60.2 (Autoplay added in Firefox 74, Firefox ESR 68.6, Autoplay Default/Locked added in Firefox 76, Firefox ESR 68.8, VirtualReality added in Firefox 80, Firefox ESR 78.2, ScreenShare added in Firefox 142, Firefox ESR 140.2)\
+## Compatibility
+
+<PolicyCompat policy="Permissions" />
+
+`Autoplay` added in Firefox 74, Firefox ESR 68.6, `Default`/`Locked` added in Firefox 76, Firefox ESR 68.8, `VirtualReality` added in Firefox 80, Firefox ESR 78.2, `ScreenShare` added in Firefox 142, Firefox ESR 140.2.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `permissions.default.camera`, `permissions.default.microphone`, `permissions.default.geo`, `permissions.default.desktop-notification`, `media.autoplay.default`, `permissions.default.xr`, `permissions.default.screen`
 

--- a/src/content/docs/reference/policies/PictureInPicture.mdx
+++ b/src/content/docs/reference/policies/PictureInPicture.mdx
@@ -6,7 +6,10 @@ category: "Content settings"
 
 Enable or disable Picture-in-Picture as well as prevent the user from enabling or disabling it (Locked).
 
-**Compatibility:** Firefox 78, Firefox ESR 78\
+## Compatibility
+
+<PolicyCompat policy="PictureInPicture" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `media.videocontrols.picture-in-picture.video-toggle.enabled`
 

--- a/src/content/docs/reference/policies/PopupBlocking.mdx
+++ b/src/content/docs/reference/policies/PopupBlocking.mdx
@@ -6,7 +6,10 @@ category: "Content settings"
 
 Allow certain websites to display popups and be redirected by third-party frames.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="PopupBlocking" />
+
 **CCK2 Equivalent:** `permissions.popup`\
 **Preferences Affected:** `dom.disable_open_during_load`
 

--- a/src/content/docs/reference/policies/PostQuantumKeyAgreementEnabled.mdx
+++ b/src/content/docs/reference/policies/PostQuantumKeyAgreementEnabled.mdx
@@ -16,7 +16,10 @@ The policy covers TLS, HTTP/3 as of Firefox 128, and WebRTC.
 Setting this policy locks the preferences, whether the value is `true` or `false`, so users cannot change them.
 This policy is independent of [`CNSA2KeyAgreementEnabled`](/reference/policies/cnsa2keyagreementenabled/): setting it to `false` does not stop Firefox from offering ML-KEM-1024 if that policy is enabled.
 
-**Compatibility:** Firefox 127\
+## Compatibility
+
+<PolicyCompat policy="PostQuantumKeyAgreementEnabled" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `security.tls.enable_kyber`, `network.http.http3.enable_kyber` (Firefox 128), `media.webrtc.enable_pq_hybrid_kex`
 

--- a/src/content/docs/reference/policies/Preferences.mdx
+++ b/src/content/docs/reference/policies/Preferences.mdx
@@ -17,7 +17,10 @@ You can also set default preferences, user preferences and you can clear prefere
 > There are too many preferences to provide comprehensive documentation here.
 > The source file [StaticPrefList.yaml](https://searchfox.org/mozilla-central/source/modules/libpref/init/StaticPrefList.yaml) contains information about most of them.
 
-**Compatibility:** Firefox 81, Firefox ESR 78.3\
+## Compatibility
+
+<PolicyCompat policy="Preferences" />
+
 **CCK2 Equivalent:** `preferences`\
 **Preferences Affected:** Many
 

--- a/src/content/docs/reference/policies/PrimaryPassword.mdx
+++ b/src/content/docs/reference/policies/PrimaryPassword.mdx
@@ -11,7 +11,10 @@ If this value is false, it works the same as if [`DisableMasterPasswordCreation`
 
 If both `DisableMasterPasswordCreation` and `PrimaryPassword` are used, `DisableMasterPasswordCreation` takes precedence.
 
-**Compatibility:** Firefox 79, Firefox ESR 78.1\
+## Compatibility
+
+<PolicyCompat policy="PrimaryPassword" />
+
 **CCK2 Equivalent:** `noMasterPassword`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/PrintingEnabled.mdx
+++ b/src/content/docs/reference/policies/PrintingEnabled.mdx
@@ -6,7 +6,10 @@ category: "Printing"
 
 Enable or disable printing.
 
-**Compatibility:** Firefox 120, Firefox ESR 115.5\
+## Compatibility
+
+<PolicyCompat policy="PrintingEnabled" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `print.enabled`
 

--- a/src/content/docs/reference/policies/PrivateBrowsingModeAvailability.mdx
+++ b/src/content/docs/reference/policies/PrivateBrowsingModeAvailability.mdx
@@ -10,7 +10,10 @@ This policy supersedes [`DisablePrivateBrowsing`](/reference/policies/disablepri
 
 > [!NOTE] This policy missed Firefox ESR 128.2, but it will be in Firefox ESR 128.3.
 
-**Compatibility:** Firefox 130, Firefox ESR 128.3\
+## Compatibility
+
+<PolicyCompat policy="PrivateBrowsingModeAvailability" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/PromptForDownloadLocation.mdx
+++ b/src/content/docs/reference/policies/PromptForDownloadLocation.mdx
@@ -6,7 +6,10 @@ category: "Downloads"
 
 Ask where to save each file before downloading.
 
-**Compatibility:** Firefox 68, Firefox ESR 68\
+## Compatibility
+
+<PolicyCompat policy="PromptForDownloadLocation" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.download.useDownloadDir`
 

--- a/src/content/docs/reference/policies/Proxy.mdx
+++ b/src/content/docs/reference/policies/Proxy.mdx
@@ -9,7 +9,10 @@ To specify ports, append them to the hostnames with a colon (:).
 
 Unless you lock this policy, changes the user already has in place will take effect.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="Proxy" />
+
 **CCK2 Equivalent:** `networkProxy*`\
 **Preferences Affected:** `network.proxy.type`, `network.proxy.autoconfig_url`, `network.proxy.socks_remote_dns`, `signon.autologin.proxy`, `network.proxy.socks_version`, `network.proxy.no_proxies_on`, `network.proxy.share_proxy_settings`, `network.proxy.http`, `network.proxy.http_port`, `network.proxy.ftp`, `network.proxy.ftp_port`, `network.proxy.ssl`, `network.proxy.ssl_port`, `network.proxy.socks`, `network.proxy.socks_port`
 


### PR DESCRIPTION

**Description:**

Swap out the compat info from prose to the schema.

I'm adding a H2 and replacing the content so it's at the top, although in future, we may want to move the compat info down to the bottom of the page. This is for ease of reviews at this stage.

**Motivation:**

The compat info is now tracked via schema. We can pull this in programmatically instead of in prose.

**Related issues and pull requests:**

- [x] #270
- [x] #269