### PR TITLE
chore: use PolicyCompat component instead of prose [r-x]

### DIFF
--- a/src/content/docs/reference/policies/RequestedLocales.mdx
+++ b/src/content/docs/reference/policies/RequestedLocales.mdx
@@ -1,15 +1,18 @@
 ---
 title: "RequestedLocales"
-description: "Set the the list of requested locales for the application in order of preference."
+description: "Set the list of requested locales for the application in order of preference."
 category: "Miscellaneous"
 ---
 
-Set the the list of requested locales for the application in order of preference.
+Set the list of requested locales for the application in order of preference.
 It will cause the corresponding language pack to become active.
 
-> [!NOTE] For Firefox 68, this can now be a string so that you can specify an empty value.
+## Compatibility
 
-**Compatibility:** Firefox 64, Firefox ESR 60.4, Updated in Firefox 68, Firefox ESR 68\
+<PolicyCompat policy="RequestedLocales" />
+
+As of Firefox 68, this can be a string so that you can specify an empty value.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/SSLVersionMax.mdx
+++ b/src/content/docs/reference/policies/SSLVersionMax.mdx
@@ -6,7 +6,10 @@ category: "Network security"
 
 Set and lock the maximum version of TLS (Firefox defaults to a maximum of TLS 1.3).
 
-**Compatibility:** Firefox 66, Firefox ESR 60.6\
+## Compatibility
+
+<PolicyCompat policy="SSLVersionMax" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `security.tls.version.max`
 

--- a/src/content/docs/reference/policies/SSLVersionMin.mdx
+++ b/src/content/docs/reference/policies/SSLVersionMin.mdx
@@ -6,7 +6,10 @@ category: "Network security"
 
 Set and lock the minimum version of TLS (Firefox defaults to a minimum of TLS 1.2).
 
-**Compatibility:** Firefox 66, Firefox ESR 60.6\
+## Compatibility
+
+<PolicyCompat policy="SSLVersionMin" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `security.tls.version.min`
 

--- a/src/content/docs/reference/policies/SanitizeOnShutdown.mdx
+++ b/src/content/docs/reference/policies/SanitizeOnShutdown.mdx
@@ -10,7 +10,12 @@ Items that can be selectively deleted include browsing & download history, cooki
 
 > [!NOTE] Starting with Firefox 136, `FormData` and `History` are separate data types.
 
-**Compatibility:** Firefox 60, Firefox ESR 60. Object form added in Firefox 68/ESR 68, `Locked` added in 74/68.6, `History` in Firefox 128, `Exceptions` in Firefox 154.\
+## Compatibility
+
+<PolicyCompat policy="SanitizeOnShutdown" />
+
+Object form added in Firefox 68/ESR 68, `Locked` added in 74/68.6, `History` in Firefox 128, `Exceptions` in Firefox 154.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `privacy.sanitize.sanitizeOnShutdown`, `privacy.clearOnShutdown.cache`, `privacy.clearOnShutdown.cookies`, `privacy.clearOnShutdown.downloads`, `privacy.clearOnShutdown.formdata`, `privacy.clearOnShutdown.history`, `privacy.clearOnShutdown.sessions`, `privacy.clearOnShutdown.siteSettings`, `privacy.clearOnShutdown.offlineApps`, `privacy.clearOnShutdown_v2.browsingHistoryAndDownloads` (Firefox 128), `privacy.clearOnShutdown_v2.cookiesAndStorage` (Firefox 128), `privacy.clearOnShutdown_v2.cache` (Firefox 128), `privacy.clearOnShutdown_v2.siteSettings` (Firefox 128), `privacy.clearOnShutdown_v2.formdata` (Firefox 128)
 

--- a/src/content/docs/reference/policies/SearchBar.mdx
+++ b/src/content/docs/reference/policies/SearchBar.mdx
@@ -6,7 +6,10 @@ category: "Search"
 
 Set whether or not search bar is displayed.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="SearchBar" />
+
 **CCK2 Equivalent:** `showSearchBar`\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/SearchEngines.mdx
+++ b/src/content/docs/reference/policies/SearchEngines.mdx
@@ -6,7 +6,12 @@ category: "Search"
 
 Configure search engines in Firefox. As of Firefox 139, these policies are available in all Firefox release channels.
 
-**Compatibility:** Firefox 139, Firefox ESR 60. `POST` support in Firefox ESR 68, `Encoding` in Firefox 91, `Remove` in Firefox ESR 60.2.\
+## Compatibility
+
+<PolicyCompat policy="SearchEngines" />
+
+`POST` support in Firefox ESR 68, `Encoding` in Firefox 91, `Remove` in Firefox ESR 60.2.
+
 **CCK2 Equivalent:** `searchplugins` (Add), `defaultSearchEngine` (Default), `disableSearchEngineInstall` (PreventInstalls), `removeDefaultSearchEngines` (Remove)\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/SearchSuggestEnabled.mdx
+++ b/src/content/docs/reference/policies/SearchSuggestEnabled.mdx
@@ -6,7 +6,10 @@ category: "Search"
 
 Enable search suggestions.
 
-**Compatibility:** Firefox 68, Firefox ESR 68\
+## Compatibility
+
+<PolicyCompat policy="SearchSuggestEnabled" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.urlbar.suggest.searches`, `browser.search.suggest.enabled`
 

--- a/src/content/docs/reference/policies/SecurityDevices.mdx
+++ b/src/content/docs/reference/policies/SecurityDevices.mdx
@@ -6,7 +6,12 @@ category: "Certificate management"
 
 Add or delete PKCS #11 modules.
 
-**Compatibility:** Firefox 114, Firefox ESR 112.12\
+## Compatibility
+
+<PolicyCompat policy="SecurityDevices" />
+
+The `Add` and `Delete` form was added in Firefox 114, Firefox ESR 102.12. Earlier versions map a device name directly to its module path.
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/ShowHomeButton.mdx
+++ b/src/content/docs/reference/policies/ShowHomeButton.mdx
@@ -8,7 +8,10 @@ Show the home button on the toolbar.
 
 Future versions of Firefox will not show the home button by default.
 
-**Compatibility:** Firefox 88, Firefox ESR 78.10\
+## Compatibility
+
+<PolicyCompat policy="ShowHomeButton" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/SitePolicies.mdx
+++ b/src/content/docs/reference/policies/SitePolicies.mdx
@@ -6,7 +6,10 @@ category: "Browsing restrictions"
 
 Defines policies scoped to specific sites.
 
-**Compatibility:** Firefox 150, Firefox ESR 153\
+## Compatibility
+
+<PolicyCompat policy="SitePolicies" />
+
 **Preferences Affected:** N/A
 
 The policy is made up of a list of rules that are evaluated in order.

--- a/src/content/docs/reference/policies/SkipTermsOfUse.mdx
+++ b/src/content/docs/reference/policies/SkipTermsOfUse.mdx
@@ -9,7 +9,10 @@ Configure display settings for the Firefox Terms of Use and Privacy Notice on st
 If `true`, don't display the Firefox [Terms of Use](https://www.mozilla.org/about/legal/terms/firefox/) and [Privacy Notice](https://www.mozilla.org/privacy/firefox/) upon startup.
 You represent that you accept and have the authority to accept the Terms of Use on behalf of all individuals to whom you provide access to this browser.
 
-**Compatibility:** Firefox 138, Firefox ESR 140\
+## Compatibility
+
+<PolicyCompat policy="SkipTermsOfUse" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/StartDownloadsInTempDirectory.mdx
+++ b/src/content/docs/reference/policies/StartDownloadsInTempDirectory.mdx
@@ -6,7 +6,10 @@ category: "Downloads"
 
 Force downloads to start off in a local, temporary location rather than the default download directory.
 
-**Compatibility:** Firefox 102\
+## Compatibility
+
+<PolicyCompat policy="StartDownloadsInTempDirectory" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.download.start_downloads_in_tmp_dir`
 

--- a/src/content/docs/reference/policies/SupportMenu.mdx
+++ b/src/content/docs/reference/policies/SupportMenu.mdx
@@ -6,7 +6,10 @@ category: "Browser UI"
 
 Add a menuitem to the help menu for specifying support information.
 
-**Compatibility:** Firefox 68.0.1, Firefox ESR 68.0.1\
+## Compatibility
+
+<PolicyCompat policy="SupportMenu" />
+
 **CCK2 Equivalent:** helpMenu\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/TranslateEnabled.mdx
+++ b/src/content/docs/reference/policies/TranslateEnabled.mdx
@@ -10,7 +10,10 @@ Enable or disable webpage translation.
 
 If you only want to disable the popup, you can set the `browser.translations.automaticallyPopup` preference to `false` using the [Preferences](/reference/policies/preferences/) policy.
 
-**Compatibility:** Firefox 126\
+## Compatibility
+
+<PolicyCompat policy="TranslateEnabled" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.translations.enable`
 

--- a/src/content/docs/reference/policies/UseSystemPrintDialog.mdx
+++ b/src/content/docs/reference/policies/UseSystemPrintDialog.mdx
@@ -6,7 +6,10 @@ category: "Printing"
 
 Use the system print dialog instead of the print preview window.
 
-**Compatibility:** Firefox 102\
+## Compatibility
+
+<PolicyCompat policy="UseSystemPrintDialog" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `print.prefer_system_dialog`
 

--- a/src/content/docs/reference/policies/UserMessaging.mdx
+++ b/src/content/docs/reference/policies/UserMessaging.mdx
@@ -6,7 +6,10 @@ category: "Miscellaneous"
 
 Prevent Firefox from messaging the user in certain situations.
 
-**Compatibility:** Firefox 75, Firefox ESR 68.7\
+## Compatibility
+
+<PolicyCompat policy="UserMessaging" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons`, `browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features`, `browser.aboutwelcome.enabled`, `browser.preferences.moreFromMozilla`, `browser.preferences.experimental`
 

--- a/src/content/docs/reference/policies/VisualSearchEnabled.mdx
+++ b/src/content/docs/reference/policies/VisualSearchEnabled.mdx
@@ -4,7 +4,10 @@ description: "Enable or disable visual search."
 category: "Search"
 ---
 
-**Compatibility:** Firefox 144\
+## Compatibility
+
+<PolicyCompat policy="VisualSearchEnabled" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.search.visualSearch.featureGate`
 

--- a/src/content/docs/reference/policies/WebsiteFilter.mdx
+++ b/src/content/docs/reference/policies/WebsiteFilter.mdx
@@ -7,7 +7,10 @@ category: "Browsing restrictions"
 Block websites from being visited.
 As of Firefox 83 and Firefox ESR 78.5, `file:` URLs are supported.
 
-**Compatibility:** Firefox 60, Firefox ESR 60\
+## Compatibility
+
+<PolicyCompat policy="WebsiteFilter" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/WindowsSSO.mdx
+++ b/src/content/docs/reference/policies/WindowsSSO.mdx
@@ -8,7 +8,10 @@ Allow Windows single sign-on for Microsoft, work, and school accounts.
 
 If this policy is set to `true`, Firefox will use credentials stored in Windows to sign in to Microsoft, work, and school accounts.
 
-**Compatibility:** Firefox 91\
+## Compatibility
+
+<PolicyCompat policy="WindowsSSO" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.http.windows-sso.enabled`
 

--- a/src/content/docs/reference/policies/XSLTEnabled.mdx
+++ b/src/content/docs/reference/policies/XSLTEnabled.mdx
@@ -6,7 +6,10 @@ category: "Content settings"
 
 Enable or disable support for the [XSLTProcessor](https://developer.mozilla.org/en-US/docs/Web/API/XSLTProcessor) JavaScript API and the [XSLT processing instruction](https://developer.mozilla.org/en-US/docs/Web/XML/XSLT/Reference/Element/processing-instruction).
 
-**Compatibility:** Firefox 151\
+## Compatibility
+
+<PolicyCompat policy="XSLTEnabled" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `dom.xslt.enabled`
 


### PR DESCRIPTION

**Description:**

Swap out the compat info from prose to the schema.

I'm adding a H2 and replacing the content so it's at the top, although in future, we may want to move the compat info down to the bottom of the page. This is for ease of reviews at this stage.

Also fix a typo `the the` -> `the`, it looks like this has also propagated to the schema :(

**Motivation:**

The compat info is now tracked via schema. We can pull this in programmatically instead of in prose.

**Related issues and pull requests:**

- [x] #270
- [x] #272
- [x] #269

cc @1rneh 