### PR TITLE
fix: correct `q` to state cookie Beavior instead, contrib docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,19 @@ The schema is derived from the `schema/policies-schema.json` entry, with the fol
 Policies absent from `schema/policies-schema.json` render a `Missing schema` message rather than blocking the build.
 See `src/components/PolicySchema.astro` for details.
 
+### Policy compatibility
+
+Each reference page shows a table under `## Compatibility` giving the first Firefox, Firefox ESR, and Firefox Enterprise version that supports the policy.
+The versions come from the policy's `x-compatibility` entry in `schema/policies-schema.json`, so they follow `npm run schema:sync` instead of being maintained by hand.
+
+To add the table to a policy page, use the `PolicyCompat` component and pass the policy name as `policy="policy-name"`:
+
+```mdx
+<PolicyCompat policy="MyCoolPolicy" />
+```
+
+Anything the table cannot express belongs in prose directly below it.
+
 ## Changelog
 
 The changelog is based on **Firefox versions**, not documentation versions.  

--- a/src/content/docs/reference/policies/Cookies.mdx
+++ b/src/content/docs/reference/policies/Cookies.mdx
@@ -10,7 +10,7 @@ Configure cookie preferences.
 
 <PolicyCompat policy="Cookies" />
 
-`RejectTracker` added in Firefox 63, `AllowSession` added in Firefox 79/78.1, `q` added in Firefox 95/91.4, `reject-tracker-and-partition-foreign` renamed to `partition-foreign` in Firefox 153.
+`RejectTracker` added in Firefox 63, `AllowSession` added in Firefox 79/78.1, `Behavior` added in Firefox 95/91.4, `reject-tracker-and-partition-foreign` renamed to `partition-foreign` in Firefox 153.
 
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `network.cookie.cookieBehavior`, `network.cookie.cookieBehavior.pbmode`, `network.cookie.lifetimePolicy`


### PR DESCRIPTION
**Description:**

Adds a CONTRIBUTING.md entry for hints.

**Motivation:**

Better guidelines for contributing. For the typo fix, the `q` param is wrong, it should be Behavior.


See https://support.mozilla.org/en-US/kb/firefox-enterprise-95-release-notes