### PR TITLE
fix: multiple fixes, xrefs, external links

### DIFF
--- a/src/content/docs/reference/policies/BlockAboutConfig.mdx
+++ b/src/content/docs/reference/policies/BlockAboutConfig.mdx
@@ -1,10 +1,10 @@
 ---
 title: "BlockAboutConfig"
-description: "Block access to 'about:config'."
+description: "Block access to Advanced Preferences ('about:config')."
 category: "Security"
 ---
 
-Block access to Advance Preferences (`about:config`).
+Block access to Advanced Preferences (`about:config`).
 
 ## Compatibility
 

--- a/src/content/docs/reference/policies/EnableTrackingProtection.mdx
+++ b/src/content/docs/reference/policies/EnableTrackingProtection.mdx
@@ -4,7 +4,7 @@ description: "Configure tracking protection."
 category: "Network security"
 ---
 
-Configure tracking protection.
+Configure [Enhanced Tracking Protection in Firefox](https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop).
 
 If this policy is not configured, tracking protection is not enabled by default in the browser, but it is enabled by default in private browsing and the user can change it.
 
@@ -12,7 +12,7 @@ If this policy is not configured, tracking protection is not enabled by default 
 
 <PolicyCompat policy="EnableTrackingProtection" />
 
-`Cryptomining` and `Fingerprinting` added in 70/68.2, `Exceptions` added in 73/68.5, `Category` added in Firefox 142/140.2.
+`Cryptomining` and `Fingerprinting` added in 70/68.2, `Exceptions` added in 73/68.5, `EmailTracking` added in 112, `Category` and `SuspectedFingerprinting` added in 142/140.2, `BaselineExceptions` and `ConvenienceExceptions` added in 145.
 
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `privacy.trackingprotection.enabled`, `privacy.trackingprotection.pbmode.enabled`, `privacy.trackingprotection.cryptomining.enabled`, `privacy.trackingprotection.fingerprinting.enabled`, `privacy.fingerprintingProtection`, `privacy.trackingprotection.emailtracking.enabled`, `privacy.trackingprotection.emailtracking.pbmode.enabled`, `privacy.trackingprotection.allow_list.baseline.enabled`, `privacy.trackingprotection.allow_list.convenience.enabled`
@@ -23,18 +23,22 @@ If this policy is not configured, tracking protection is not enabled by default 
 
 ## Values
 
-- If `Value` is set to false, tracking protection is disabled and locked in both the regular browser and private browsing.
-- If `Value` is set to true, tracking protection is enabled by default in both the regular browser and private browsing and the `Locked` value determines whether or not a user can change it.
-- If `Locked` is set to true, users cannot change tracking protection values.
-- If `Cryptomining` is set to true, cryptomining scripts on websites are blocked.
-- If `Fingerprinting` is set to true, fingerprinting scripts on websites are blocked.
-- If `EmailTracking` is set to true, hidden email tracking pixels and scripts on websites are blocked. (Firefox 112)
-- If `SuspectedFingerprinting` is set to true, Firefox reduces the amount of information exposed to websites to protect against potential fingerprinting attempts. (Firefox 142, Firefox ESR 140.2)
-- `Exceptions` are origins for which tracking protection is not enabled.
-- `Category` can be either `strict` or `standard`.
-  If category is set, it overrides all other settings except `Exceptions`, `BaselineExceptions` and `ConvenienceExceptions`, and the user cannot change the category. (Firefox 142, Firefox ESR 140.2)
-- If `BaselineExceptions` is true, Firefox will automatically apply exceptions required to avoid major website breakage. (Firefox 145)
-- If `ConvenienceExceptions` is true, Firefox will apply exceptions automatically that are only required to fix minor issues and make convenience features available. (Firefox 145)
+- `Value`: a Boolean that enables or disables tracking protection.
+  - When `true`, tracking protection is enabled by default in both the regular browser and private browsing, and the `Locked` value determines whether or not a user can change it.
+  - When `false`, tracking protection is disabled and locked in both the regular browser and private browsing.
+- `Locked`: if set to true, users cannot change tracking protection values.
+- `Cryptomining`: a Boolean that controls blocking cryptomining scripts. When `true`, cryptomining scripts on websites are blocked.
+- `Fingerprinting`: a Boolean that controls blocking fingerprinting scripts. When `true`, fingerprinting scripts on websites are blocked.
+- `EmailTracking`: a Boolean that controls blocking email tracking. When `true`, hidden email tracking pixels and scripts on websites are blocked.
+- `SuspectedFingerprinting`: a Boolean that controls protection against suspected fingerprinting.
+  When `true`, Firefox reduces the amount of information exposed to websites to protect against potential fingerprinting attempts.
+- `Exceptions`: an array of origins for which tracking protection is not enabled.
+- `Category`: a string that sets the tracking protection category, either `strict` or `standard`.
+  When set, it overrides all other settings except `Exceptions`, `BaselineExceptions` and `ConvenienceExceptions`, and the user cannot change the category.
+- `BaselineExceptions`: a Boolean that controls the exceptions required to avoid major website breakage.
+  When `true`, Firefox applies them automatically.
+- `ConvenienceExceptions`: a Boolean that controls the exceptions that are only required to fix minor issues and make convenience features available.
+  When `true`, Firefox applies them automatically.
 
 > [!NOTE]
 > Users can change `BaselineExceptions` and `ConvenienceExceptions` even when `Category` is set to `strict` unless `Locked` is set to true. If `Locked` is set to `true`, `BaselineExceptions` and `ConvenienceExceptions` use their initial values (based on the tracking protection `Category`) unless policy explicitly sets them.
@@ -208,3 +212,9 @@ Value (string):
   </dict>
 </dict>
 ```
+
+## See also
+
+- [Enhanced Tracking Protection in Firefox for desktop](https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop) on support.mozilla.org
+- [Trackers and scripts Firefox blocks in Enhanced Tracking Protection](https://support.mozilla.org/en-US/kb/trackers-and-scripts-firefox-blocks-enhanced-track) on support.mozilla.org
+- [Manage Enhanced Tracking Protection exceptions](https://support.mozilla.org/en-US/kb/manage-enhanced-tracking-protection-exceptions) on support.mozilla.org

--- a/src/content/docs/reference/policies/EncryptedMediaExtensions.mdx
+++ b/src/content/docs/reference/policies/EncryptedMediaExtensions.mdx
@@ -4,7 +4,8 @@ description: "Enable or disable Encrypted Media Extensions and optionally lock i
 category: "Content settings"
 ---
 
-Enable or disable Encrypted Media Extensions and optionally lock it.
+Enable or disable [Encrypted Media Extensions](https://developer.mozilla.org/en-US/docs/Web/API/Encrypted_Media_Extensions_API) (EME) and optionally lock it.
+EME allows Firefox to play DRM-controlled content using a Content Decryption Module such as [Google Widevine](https://developers.google.com/widevine).
 
 ## Compatibility
 
@@ -57,3 +58,8 @@ Value (string):
   </dict>
 </dict>
 ```
+
+## See also
+
+- [Watch DRM content on Firefox](https://support.mozilla.org/en-US/kb/enable-drm) on support.mozilla.org
+- [Encrypted Media Extensions API](https://developer.mozilla.org/en-US/docs/Web/API/Encrypted_Media_Extensions_API) on MDN

--- a/src/content/docs/reference/policies/MicrosoftEntraSSO.mdx
+++ b/src/content/docs/reference/policies/MicrosoftEntraSSO.mdx
@@ -8,6 +8,8 @@ Allow single sign-on for Microsoft Entra accounts on macOS.
 
 If this policy is set to `true`, Firefox will use credentials stored in the Company Portal to sign in to Microsoft Entra accounts.
 
+For the Windows equivalent, see the [`WindowsSSO`](/reference/policies/windowssso/) policy, which signs in to Microsoft, work, and school accounts using credentials stored in Windows.
+
 ## Compatibility
 
 <PolicyCompat policy="MicrosoftEntraSSO" />
@@ -27,3 +29,8 @@ If this policy is set to `true`, Firefox will use credentials stored in the Comp
   <true/> | <false/>
 </dict>
 ```
+
+## See also
+
+- [Microsoft Enterprise SSO plug-in for Apple devices](https://learn.microsoft.com/en-us/entra/identity-platform/apple-sso-plugin) on learn.microsoft.com
+- [Configure macOS Enterprise SSO app extension with MDMs](https://learn.microsoft.com/en-us/intune/intune-service/configuration/use-enterprise-sso-plug-in-macos-with-intune) on learn.microsoft.com

--- a/src/content/docs/reference/policies/Permissions.mdx
+++ b/src/content/docs/reference/policies/Permissions.mdx
@@ -5,7 +5,7 @@ category: "Content settings"
 ---
 
 Set permissions associated with camera, microphone, location, notifications, autoplay, and virtual reality.
-Because these are origins, not domains, entries with unique ports must be specified separately.
+Because these are [origins](https://developer.mozilla.org/en-US/docs/Glossary/Origin), not domains, entries with unique ports must be specified separately.
 This explicitly means that it is not possible to add wildcards. See examples below.
 
 ## Compatibility
@@ -524,3 +524,8 @@ Value (string):
   </dict>
 </dict>
 ```
+
+## See also
+
+- [How to manage your camera and microphone permissions with Firefox](https://support.mozilla.org/en-US/kb/how-manage-your-camera-and-microphone-permissions) on support.mozilla.org
+- [Allow or block media autoplay in Firefox](https://support.mozilla.org/en-US/kb/block-autoplay) on support.mozilla.org

--- a/src/content/docs/reference/policies/PictureInPicture.mdx
+++ b/src/content/docs/reference/policies/PictureInPicture.mdx
@@ -4,7 +4,7 @@ description: "Enable or disable Picture-in-Picture as well as prevent the user f
 category: "Content settings"
 ---
 
-Enable or disable Picture-in-Picture as well as prevent the user from enabling or disabling it (Locked).
+Enable or disable [Picture-in-Picture](https://support.mozilla.org/en-US/kb/about-picture-picture-firefox) as well as prevent the user from enabling or disabling it (`Locked`).
 
 ## Compatibility
 
@@ -53,3 +53,7 @@ Value (string):
   </dict>
 </dict>
 ```
+
+## See also
+
+- [Turn picture-in-picture mode controls on and off](https://support.mozilla.org/en-US/kb/turn-picture-picture-mode) on support.mozilla.org

--- a/src/content/docs/reference/policies/PopupBlocking.mdx
+++ b/src/content/docs/reference/policies/PopupBlocking.mdx
@@ -4,7 +4,8 @@ description: "Allow certain websites to display popups and be redirected by thir
 category: "Content settings"
 ---
 
-Allow certain websites to display popups and be redirected by third-party frames.
+Allow certain websites to display popups and be [redirected by third-party frames](https://support.mozilla.org/en-US/kb/pop-blocker-settings-exceptions-troubleshooting).
+Third-party redirect blocking is an extension of the pop-up blocker, so the same origins and settings apply to both.
 
 ## Compatibility
 

--- a/src/content/docs/reference/policies/PromptForDownloadLocation.mdx
+++ b/src/content/docs/reference/policies/PromptForDownloadLocation.mdx
@@ -45,3 +45,9 @@ Value (string):
   <true/> | <false/>
 </dict>
 ```
+
+## See also
+
+- [`DefaultDownloadDirectory`](/reference/policies/defaultdownloaddirectory/) policy, which sets the default download directory.
+- [`DownloadDirectory`](/reference/policies/downloaddirectory/) policy, which sets and locks the download directory.
+- [`StartDownloadsInTempDirectory`](/reference/policies/startdownloadsintempdirectory/) policy, which forces downloads to start in a temporary location.

--- a/src/content/docs/reference/policies/RequestedLocales.mdx
+++ b/src/content/docs/reference/policies/RequestedLocales.mdx
@@ -11,7 +11,7 @@ It will cause the corresponding language pack to become active.
 
 <PolicyCompat policy="RequestedLocales" />
 
-As of Firefox 68, this can be a string so that you can specify an empty value.
+As of Firefox 68, this can be a string so that you can specify an empty value (`""`).
 
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
@@ -63,5 +63,4 @@ or
   <key>RequestedLocales</key>
   <string>de,en-US</string>
 </dict>
-
 ```

--- a/src/content/docs/reference/policies/SearchBar.mdx
+++ b/src/content/docs/reference/policies/SearchBar.mdx
@@ -4,7 +4,7 @@ description: "Set whether or not search bar is displayed."
 category: "Search"
 ---
 
-Set whether or not search bar is displayed.
+Set whether or not the [search bar](https://support.mozilla.org/en-US/kb/add-search-bar-firefox-toolbar) is displayed.
 
 ## Compatibility
 
@@ -46,3 +46,8 @@ Value (string):
   <string>unified | separate</string>
 </dict>
 ```
+
+## See also
+
+- [Add the Search bar to your Firefox toolbar](https://support.mozilla.org/en-US/kb/add-search-bar-firefox-toolbar) on support.mozilla.org
+- [Search with the Firefox address bar](https://support.mozilla.org/en-US/kb/search-firefox-address-bar) on support.mozilla.org

--- a/src/content/docs/reference/policies/WindowsSSO.mdx
+++ b/src/content/docs/reference/policies/WindowsSSO.mdx
@@ -41,4 +41,5 @@ Value (string):
 
 ## See also
 
+- [`MicrosoftEntraSSO`](/reference/policies/microsoftentrasso/) policy, which is the macOS counterpart and signs in to Microsoft Entra accounts using credentials stored in the Company Portal.
 - [Configuring policies](/guides/policies-configuration/) guide


### PR DESCRIPTION

**Description:**

I went through the docs and flagged some areas for improvement. This PR cleans up:

- moving compat info out of prose up to compat section
- External links where necessary (product docs, technical references)
- Xrefs where policies had platform-specific equivalents or related concepts
- formatting fixes


**Motivation:**

Increasing the quality of the docs

**Related issues and pull requests:**

Related to:

- [x] https://github.com/mozilla/enterprise-admin-reference/pull/277