### PR TITLE
fix: multiple fixes, xrefs, external links, pt. 2

### DIFF
--- a/src/content/docs/reference/policies/DNSOverHTTPS.mdx
+++ b/src/content/docs/reference/policies/DNSOverHTTPS.mdx
@@ -7,7 +7,7 @@ category: "Network security"
 Configure [DNS over HTTPS](https://support.mozilla.org/en-US/kb/firefox-dns-over-https).
 
 DNS over HTTPS (DoH) sends DNS lookups over an encrypted HTTPS connection to a trusted resolver instead of sending them in plain text to a local resolver.
-This stops the network from seeing or tampering with the hostnames Firefox looks up, but lookups no longer go through your DNS infrastructure unless you use a `ProviderURL`.
+This makes it harder for the network to see or modify lookups, but they no longer go through your DNS infrastructure unless you use a `ProviderURL`.
 
 ## Compatibility
 

--- a/src/content/docs/reference/policies/DNSOverHTTPS.mdx
+++ b/src/content/docs/reference/policies/DNSOverHTTPS.mdx
@@ -4,7 +4,10 @@ description: "Configure DNS over HTTPS (DoH)."
 category: "Network security"
 ---
 
-Configure DNS over HTTPS.
+Configure [DNS over HTTPS](https://support.mozilla.org/en-US/kb/firefox-dns-over-https).
+
+DNS over HTTPS (DoH) sends DNS lookups over an encrypted HTTPS connection to a trusted resolver instead of sending them in plain text to a local resolver.
+This stops the network from seeing or tampering with the hostnames Firefox looks up, but lookups no longer go through your DNS infrastructure unless you use a `ProviderURL`.
 
 ## Compatibility
 
@@ -13,7 +16,7 @@ Configure DNS over HTTPS.
 `ExcludedDomains` added in 75/68.7, `Fallback` added in 124.
 
 **CCK2 Equivalent:** N/A\
-**Preferences Affected:** `network.trr.mode`, `network.trr.uri`
+**Preferences Affected:** `network.trr.mode`, `network.trr.uri`, `network.trr.excluded-domains`
 
 ## Examples
 
@@ -21,11 +24,19 @@ Configure DNS over HTTPS.
 
 ## Values
 
-- `Enabled` determines whether DNS over HTTPS is enabled
-- `ProviderURL` is a URL to another provider.
+- `Enabled` determines whether DNS over HTTPS is enabled.
+- `ProviderURL` is a URL to a DOH provider. If it is not set, Firefox uses its own default provider.
 - `Locked` prevents the user from changing DNS over HTTPS preferences.
-- `ExcludedDomains` excludes domains from DNS over HTTPS.
+- `ExcludedDomains` excludes domains from DNS over HTTPS, so they are resolved by the system resolver instead. Use this for internal hostnames that only your own DNS servers can resolve.
 - `Fallback` determines whether or not Firefox will use your default DNS resolver if there is a problem with the secure DNS provider.
+
+`Enabled` and `Fallback` together set the `network.trr.mode` preference:
+
+| `Enabled` | `Fallback`       | `network.trr.mode` | Behavior                                                                  |
+| --------- | ---------------- | ------------------ | ------------------------------------------------------------------------- |
+| `true`    | `true` (default) | 2                  | Firefox tries DNS over HTTPS first and falls back to the system resolver. |
+| `true`    | `false`          | 3                  | Firefox only uses DNS over HTTPS, and a failed lookup is an error.        |
+| `false`   | not applicable   | 5                  | DNS over HTTPS is off.                                                    |
 
 ## Windows (GPO)
 
@@ -122,3 +133,9 @@ Value (string):
   </dict>
 </dict>
 ```
+
+## See also
+
+- [Configure DNS over HTTPS protection levels in Firefox](https://support.mozilla.org/en-US/kb/dns-over-https) on support.mozilla.org
+- [Configure networks to disable DNS over HTTPS](https://support.mozilla.org/en-US/kb/configuring-networks-disable-dns-over-https) on support.mozilla.org
+- [Security/DOH-resolver-policy](https://wiki.mozilla.org/Security/DOH-resolver-policy) on wiki.mozilla.org

--- a/src/content/docs/reference/policies/DisableSecurityBypass.mdx
+++ b/src/content/docs/reference/policies/DisableSecurityBypass.mdx
@@ -13,6 +13,8 @@ This policy removes the bypasses, so the user cannot reach the page from inside 
 These policies only affect what happens when an error is shown, they do not affect any settings in preferences.
 To change what gets blocked, use [Preferences](/reference/policies/preferences/) to set the relevant `browser.safebrowsing.*` preferences.
 
+If Firefox rejects a certificate that your organization needs to trust, add it with the [`Certificates`](/reference/policies/certificates/) policy instead.
+
 ## Compatibility
 
 <PolicyCompat policy="DisableSecurityBypass" />
@@ -76,3 +78,8 @@ Value (string):
   </dict>
 </dict>
 ```
+
+## See also
+
+- [What do the security warning codes mean?](https://support.mozilla.org/en-US/kb/what-does-your-connection-is-not-secure-mean) on support.mozilla.org
+- [How does built-in Phishing and Malware Protection work?](https://support.mozilla.org/en-US/kb/how-does-phishing-and-malware-protection-work) on support.mozilla.org

--- a/src/content/docs/reference/policies/DisableSystemAddonUpdate.mdx
+++ b/src/content/docs/reference/policies/DisableSystemAddonUpdate.mdx
@@ -6,6 +6,11 @@ category: "Device update settings"
 
 Prevent system add-ons from being installed or updated.
 
+System add-ons are built-in Firefox features that are implemented as extensions so that Mozilla can ship and update them independently of the Firefox release cycle.
+Because Firefox treats them as part of the browser rather than as user add-ons, they are not managed from the Add-ons Manager.
+
+If this policy is set to `true`, Firefox does not install new system add-ons or update the ones it already has, so a profile keeps only the versions that shipped with the installed build.
+
 ## Compatibility
 
 <PolicyCompat policy="DisableSystemAddonUpdate" />
@@ -45,3 +50,7 @@ Value (string):
   <true/> | <false/>
 </dict>
 ```
+
+## See also
+
+- [System Add-ons Overview](https://firefox-source-docs.mozilla.org/toolkit/mozapps/extensions/addon-manager/SystemAddons.html) on firefox-source-docs.mozilla.org

--- a/src/content/docs/reference/policies/DisableSystemAddonUpdate.mdx
+++ b/src/content/docs/reference/policies/DisableSystemAddonUpdate.mdx
@@ -9,7 +9,7 @@ Prevent system add-ons from being installed or updated.
 System add-ons are built-in Firefox features that are implemented as extensions so that Mozilla can ship and update them independently of the Firefox release cycle.
 Because Firefox treats them as part of the browser rather than as user add-ons, they are not managed from the Add-ons Manager.
 
-If this policy is set to `true`, Firefox does not install new system add-ons or update the ones it already has, so a profile keeps only the versions that shipped with the installed build.
+If this policy is set to `true`, Firefox does not install new system add-ons or update existing system add-ons through the system add-on update mechanism.
 
 ## Compatibility
 

--- a/src/content/docs/reference/policies/Homepage.mdx
+++ b/src/content/docs/reference/policies/Homepage.mdx
@@ -6,6 +6,9 @@ category: "Startup"
 
 Configure the default homepage and how Firefox starts.
 
+This policy covers startup and the Home button.
+It does not change what a new tab shows: use the [`NewTabPage`](/reference/policies/newtabpage/) policy to turn the New Tab page off, or the [`FirefoxHome`](/reference/policies/firefoxhome/) policy to change the sections on it.
+
 ## Compatibility
 
 <PolicyCompat policy="Homepage" />

--- a/src/content/docs/reference/policies/HttpsOnlyMode.mdx
+++ b/src/content/docs/reference/policies/HttpsOnlyMode.mdx
@@ -4,7 +4,10 @@ description: "Configure HTTPS-Only Mode."
 category: "Network security"
 ---
 
-Configure HTTPS-Only Mode.
+Configure [HTTPS-Only Mode](https://support.mozilla.org/en-US/kb/https-only-prefs).
+
+In HTTPS-Only Mode, Firefox upgrades every connection to HTTPS and shows a warning page when a site is only available over HTTP.
+To exempt specific sites from the upgrade, use the [`HttpAllowlist`](/reference/policies/httpallowlist/) policy.
 
 ## Compatibility
 

--- a/src/content/docs/reference/policies/HttpsOnlyMode.mdx
+++ b/src/content/docs/reference/policies/HttpsOnlyMode.mdx
@@ -6,7 +6,7 @@ category: "Network security"
 
 Configure [HTTPS-Only Mode](https://support.mozilla.org/en-US/kb/https-only-prefs).
 
-In HTTPS-Only Mode, Firefox upgrades every connection to HTTPS and shows a warning page when a site is only available over HTTP.
+In HTTPS-Only Mode, Firefox attempts to upgrade every connection to HTTPS and shows a warning page when a site is only available over HTTP.
 To exempt specific sites from the upgrade, use the [`HttpAllowlist`](/reference/policies/httpallowlist/) policy.
 
 ## Compatibility

--- a/src/content/docs/reference/policies/HttpsOnlyMode.mdx
+++ b/src/content/docs/reference/policies/HttpsOnlyMode.mdx
@@ -6,7 +6,7 @@ category: "Network security"
 
 Configure [HTTPS-Only Mode](https://support.mozilla.org/en-US/kb/https-only-prefs).
 
-In HTTPS-Only Mode, Firefox attempts to upgrade every connection to HTTPS and shows a warning page when a site is only available over HTTP.
+In HTTPS-Only Mode, Firefox attempts to upgrade HTTP connections to HTTPS and shows a warning page when a site is only available over HTTP.
 To exempt specific sites from the upgrade, use the [`HttpAllowlist`](/reference/policies/httpallowlist/) policy.
 
 ## Compatibility

--- a/src/content/docs/reference/policies/LocalFileLinks.mdx
+++ b/src/content/docs/reference/policies/LocalFileLinks.mdx
@@ -4,14 +4,20 @@ description: "Enable linking to local files by origin."
 category: "Network security"
 ---
 
-Enable linking to local files by origin.
+Enable linking to local files by [origin](https://developer.mozilla.org/en-US/docs/Glossary/Origin).
+
+By default, a page served over `http://` or `https://` cannot link to a `file:///` URL.
+Firefox blocks the navigation and reports a security error in the browser console.
+
+This policy lists the origins that are allowed to link to the local file system.
+Intranet applications may need this, for example, to link to files on a shared drive.
 
 ## Compatibility
 
 <PolicyCompat policy="LocalFileLinks" />
 
 **CCK2 Equivalent:** N/A\
-**Preferences Affected:** `capability.policy.localfilelinks.*`
+**Preferences Affected:** `capability.policy.policynames`, `capability.policy.localfilelinks_*`
 
 ## Examples
 
@@ -50,3 +56,7 @@ Value (string):
   </array>
 </dict>
 ```
+
+## See also
+
+- [File URI scheme](https://en.wikipedia.org/wiki/File_URI_scheme) on wikipedia.org

--- a/src/content/docs/reference/policies/LocalNetworkAccess.mdx
+++ b/src/content/docs/reference/policies/LocalNetworkAccess.mdx
@@ -7,6 +7,10 @@ category: "Network security"
 Configure local network access security features.
 The `LocalNetworkAccess` policy controls Firefox's behavior when websites attempt to access local network resources (localhost and local network addresses).
 
+Without these checks, websites can send requests to devices such as routers, printers, or IoT devices on the user's network.
+This can be dangerous because some devices assume that requests originating from the local network are trusted, and this allow for attacks such as [cross-site request forgery](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/CSRF).
+Local network access protections require permission before a website can make requests to local or loopback addresses, where applicable.
+
 ## Compatibility
 
 <PolicyCompat policy="LocalNetworkAccess" />
@@ -153,3 +157,8 @@ Value (string):
   </dict>
 </dict>
 ```
+
+## See also
+
+- [Local network access](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Local_network_access) on MDN
+- [Local Network Access](https://wicg.github.io/local-network-access/) specification in the W3C Web Incubator Community Group

--- a/src/content/docs/reference/policies/LocalNetworkAccess.mdx
+++ b/src/content/docs/reference/policies/LocalNetworkAccess.mdx
@@ -4,11 +4,11 @@ description: "Configure local network access security features."
 category: "Network security"
 ---
 
-Configure local network access security features.
+Configure local network access (LNA) security features.
 The `LocalNetworkAccess` policy controls Firefox's behavior when websites attempt to access local network resources (localhost and local network addresses).
 
 Without these checks, websites can send requests to devices such as routers, printers, or IoT devices on the user's network.
-This can be dangerous because some devices assume that requests originating from the local network are trusted, and this allow for attacks such as [cross-site request forgery](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/CSRF).
+This can be dangerous because some devices assume that requests originating from the local network are trusted, which can enable attacks such as [cross-site request forgery](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/CSRF).
 Local network access protections require permission before a website can make requests to local or loopback addresses, where applicable.
 
 ## Compatibility
@@ -35,6 +35,13 @@ Local network access protections require permission before a website can make re
   Users will be asked to grant permission before a website can access local resources.
 - `SkipDomains`: an array of domain names for which local network access checks should be skipped. This allows administrators to create exceptions for trusted domains.
 - `Locked`: if set to true, users cannot change the local network access settings.
+
+> [!NOTE]
+> `BlockTrackers` and `EnablePrompting` only apply when `Enabled` is explicitly set to `true`, and both default to `true` if they are not defined.
+> Firefox does not block trackers from LNA by default, and setting `Enabled` to `true` on its own also turns LNA tracker blocking on.
+>
+> Setting `Enabled` to `false` turns both permission prompting and blocking third-party trackers off.
+> `SkipDomains` is applied independently, whether or not `Enabled` is defined.
 
 ## Description
 

--- a/src/content/docs/reference/policies/NewTabPage.mdx
+++ b/src/content/docs/reference/policies/NewTabPage.mdx
@@ -6,6 +6,12 @@ category: "Startup"
 
 Enable or disable the New Tab page.
 
+If this policy is set to `false`, new tabs open a blank page instead of Firefox Home.
+
+This policy only covers new tabs.
+To configure what Firefox opens at startup, and what the Home button loads, see the [`Homepage`](/reference/policies/homepage/) policy.
+To keep the New Tab page but change which sections appear on it, use the [`FirefoxHome`](/reference/policies/firefoxhome/) policy.
+
 ## Compatibility
 
 <PolicyCompat policy="NewTabPage" />

--- a/src/content/docs/reference/policies/OverrideFirstRunPage.mdx
+++ b/src/content/docs/reference/policies/OverrideFirstRunPage.mdx
@@ -6,14 +6,19 @@ category: "Startup"
 
 Override the first run page. If the value is an empty string (`""`), the first run page is not displayed.
 
+The first run page is what Firefox opens the first time a new profile is used, normally the onboarding tour at `about:welcome`.
+Setting this policy replaces that page and turns the onboarding tour off, so users go directly to the URL you specify.
+
 Starting with Firefox 83, Firefox ESR 78.5, you can also specify multiple URLs separated by a vertical bar (`|`).
+
+For the page shown after Firefox updates, see the [`OverridePostUpdatePage`](/reference/policies/overridepostupdatepage/) policy.
 
 ## Compatibility
 
 <PolicyCompat policy="OverrideFirstRunPage" />
 
 **CCK2 Equivalent:** `welcomePage`,`noWelcomePage`\
-**Preferences Affected:** `startup.homepage_welcome_url`
+**Preferences Affected:** `startup.homepage_welcome_url`, `browser.aboutwelcome.enabled`
 
 ## Examples
 

--- a/src/content/docs/reference/policies/OverridePostUpdatePage.mdx
+++ b/src/content/docs/reference/policies/OverridePostUpdatePage.mdx
@@ -6,6 +6,12 @@ category: "Startup"
 
 Override the upgrade page. If the value is an empty string (`""`), no extra pages are displayed when Firefox is upgraded.
 
+The upgrade page, also called the "What's New" page, is the extra tab Firefox opens the first time it starts after updating to a new version.
+It is normally a page on mozilla.org describing what changed in that release.
+Setting this policy replaces that page and stops Firefox from using a page supplied with the update itself.
+
+For the page shown the first time a new profile is used, see the [`OverrideFirstRunPage`](/reference/policies/overridefirstrunpage/) policy.
+
 ## Compatibility
 
 <PolicyCompat policy="OverridePostUpdatePage" />

--- a/src/content/docs/reference/policies/PasswordManagerEnabled.mdx
+++ b/src/content/docs/reference/policies/PasswordManagerEnabled.mdx
@@ -10,10 +10,10 @@ Remove access to the password manager via preferences and block `about:logins`.
 
 <PolicyCompat policy="PasswordManagerEnabled" />
 
-`about:logins` blocking added in Firefox 70.
+`about:logins` blocking added in Firefox 70, `browser.contextual-password-manager.enabled` also set from Firefox 154.
 
 **CCK2 Equivalent:** N/A\
-**Preferences Affected:** `pref.privacy.disable_button.view_passwords`, `signon.rememberSignons`
+**Preferences Affected:** `pref.privacy.disable_button.view_passwords`, `signon.rememberSignons`, `browser.contextual-password-manager.enabled`
 
 ## Examples
 

--- a/src/content/docs/reference/policies/PasswordManagerEnabled.mdx
+++ b/src/content/docs/reference/policies/PasswordManagerEnabled.mdx
@@ -4,11 +4,13 @@ description: "Remove access to the password manager via preferences and blocks a
 category: "Password manager"
 ---
 
-Remove access to the password manager via preferences and blocks about:logins on Firefox 70.
+Remove access to the password manager via preferences and block `about:logins`.
 
 ## Compatibility
 
 <PolicyCompat policy="PasswordManagerEnabled" />
+
+`about:logins` blocking added in Firefox 70.
 
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `pref.privacy.disable_button.view_passwords`, `signon.rememberSignons`


### PR DESCRIPTION
**Description:**

I went through the docs and flagged some areas for improvement. This PR cleans up:

- moving compat info out of prose up to compat section
- External links where necessary (product docs, technical references)
- Xrefs where policies had platform-specific equivalents or related concepts
- formatting fixes

**Motivation:**

Increasing the quality of the docs

**Related issues and pull requests:**

Related to:

- [x] https://github.com/mozilla/enterprise-admin-reference/pull/277
- [x] #278