### PR TITLE
fix: multiple fixes, xrefs, external links, pt. 3

### DIFF
--- a/src/content/docs/reference/policies/SSLVersionMax.mdx
+++ b/src/content/docs/reference/policies/SSLVersionMax.mdx
@@ -4,7 +4,14 @@ description: "Set and lock the maximum version of TLS."
 category: "Network security"
 ---
 
-Set and lock the maximum version of TLS (Firefox defaults to a maximum of TLS 1.3).
+Set and lock the maximum version of [TLS](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Transport_Layer_Security).
+Firefox defaults to a maximum of TLS 1.3, meaning this policy can ensure users or other configuration mechanisms can't lower it.
+
+For setting and locking the minimum version of TLS, see the [`SSLVersionMin`](/reference/policies/sslversionmin/) policy.
+
+> [!WARNING]
+> TLS 1.0 and TLS 1.1 are deprecated.
+> It's not recommended to set a maximum of `tls1` or `tls1.1`, which stops Firefox from using TLS 1.2 and above.
 
 ## Compatibility
 
@@ -35,7 +42,7 @@ Value (string):
 
 ```xml
 <enabled/>
-<data id="SSLVersion" value="tls1 | tls1.2 | tls1.3"/>
+<data id="SSLVersion" value="tls1 | tls1.1 | tls1.2 | tls1.3"/>
 ```
 
 ## macOS

--- a/src/content/docs/reference/policies/SSLVersionMin.mdx
+++ b/src/content/docs/reference/policies/SSLVersionMin.mdx
@@ -4,7 +4,14 @@ description: "Set and lock the minimum version of TLS."
 category: "Network security"
 ---
 
-Set and lock the minimum version of TLS (Firefox defaults to a minimum of TLS 1.2).
+Set and lock the minimum version of [TLS](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Transport_Layer_Security).
+Firefox defaults to a minimum of TLS 1.2, meaning this policy can ensure users or other configuration mechanisms can't lower it.
+
+For setting and locking the maximum version of TLS, see the [`SSLVersionMax`](/reference/policies/sslversionmax/) policy.
+
+> [!WARNING]
+> TLS 1.0 and TLS 1.1 are deprecated, meaning it's not recommended to enable anything lower than TLS 1.2.
+> Setting a minimum of `tls1` or `tls1.1` re-enables them for every site, and the cipher suites those versions rely on may also need to be turned back on with the `security.tls.version.enable-deprecated` preference.
 
 ## Compatibility
 
@@ -35,7 +42,7 @@ Value (string):
 
 ```xml
 <enabled/>
-<data id="SSLVersion" value="tls1 | tls1.2 | tls1.3"/>
+<data id="SSLVersion" value="tls1 | tls1.1 | tls1.2 | tls1.3"/>
 ```
 
 ## macOS

--- a/src/content/docs/reference/policies/SearchSuggestEnabled.mdx
+++ b/src/content/docs/reference/policies/SearchSuggestEnabled.mdx
@@ -4,7 +4,13 @@ description: "Enable search suggestions."
 category: "Search"
 ---
 
-Enable search suggestions.
+Enable [search suggestions](https://support.mozilla.org/en-US/kb/search-suggestions-firefox).
+
+When search suggestions are enabled, the text you type into the address bar or [Search bar](https://support.mozilla.org/en-US/kb/add-search-bar-firefox-toolbar) is sent to the default search engine.
+The search engine analyzes the submitted text and displays a list of popular results based on the search term.
+The `SearchSuggestEnabled` policy covers both the address bar and the separate search bar, and locks the setting so the user cannot change it.
+
+For the Firefox Suggest results that come from Mozilla rather than from the search engine, use the [`FirefoxSuggest`](/reference/policies/firefoxsuggest/) policy.
 
 ## Compatibility
 

--- a/src/content/docs/reference/policies/SecurityDevices.mdx
+++ b/src/content/docs/reference/policies/SecurityDevices.mdx
@@ -4,13 +4,17 @@ description: "Add or delete PKCS #11 modules."
 category: "Certificate management"
 ---
 
-Add or delete PKCS #11 modules.
+Add or delete [PKCS #11 modules](https://en.wikipedia.org/wiki/PKCS_11).
+
+A PKCS #11 module is an external library that lets Firefox talk to a cryptographic device such as a smart card or hardware token, so that certificates and keys on that device can be used for client authentication.
+The `SecurityDevices` policy loads those libraries instead of requiring the user to manage them manually from the Security Devices dialog in Settings.
 
 ## Compatibility
 
 <PolicyCompat policy="SecurityDevices" />
 
-The `Add` and `Delete` form was added in Firefox 114, Firefox ESR 102.12. Earlier versions map a device name directly to its module path.
+The `Add` and `Delete` form was added in Firefox 114, Firefox ESR 102.12.
+Earlier versions map a device name directly to its module path (see [legacy SecurityDevices implementation](https://mozilla.github.io/policy-templates/#securitydevices-deprecated) for details).
 
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
@@ -19,11 +23,18 @@ The `Add` and `Delete` form was added in Firefox 114, Firefox ESR 102.12. Earlie
 
 <PolicyExample policy="SecurityDevices" />
 
+## Values
+
+- `Add` maps a device name to the full path of the module library on disk.
+  The name is what the device is listed as in Firefox, and the path must be readable on the machine where Firefox runs.
+- `Delete` is a list of device names to unload, using the name the module was added under.
+  Removing a name that is not loaded is not an error.
+
 ## Windows (GPO)
 
 ```
 Software\Policies\Mozilla\Firefox\SecurityDevices\Add\NAME_OF_DEVICE_TO_ADD = PATH_TO_LIBRARY_FOR_DEVICE
-Software\Policies\Mozilla\Firefox\SecurityDevices\Remove\1 = NAME_OF_DEVICE_TO_REMOVE
+Software\Policies\Mozilla\Firefox\SecurityDevices\Delete\1 = NAME_OF_DEVICE_TO_DELETE
 ```
 
 ## Windows (Intune)
@@ -60,20 +71,15 @@ Value (string):
 <dict>
   <key>SecurityDevices</key>
   <dict>
-    <key>Add<key>
+    <key>Add</key>
     <dict>
       <key>NAME_OF_DEVICE_TO_ADD</key>
       <string>PATH_TO_LIBRARY_FOR_DEVICE</string>
     </dict>
-    <key>Delete</add>
+    <key>Delete</key>
     <array>
       <string>NAME_OF_DEVICE_TO_DELETE</string>
     </array>
   </dict>
 </dict>
 ```
-
-## See also
-
-- Since Firefox 114, this policy expects `Add` and `Delete` keys instead of a single `"name" : "path"` combination.
-  See [SecurityDevices](https://mozilla.github.io/policy-templates/#securitydevices-deprecated) for the syntax prior to Firefox 114.

--- a/src/content/docs/reference/policies/SitePolicies.mdx
+++ b/src/content/docs/reference/policies/SitePolicies.mdx
@@ -4,32 +4,20 @@ description: "Fine grained control over policies for specific sites."
 category: "Browsing restrictions"
 ---
 
-Defines policies scoped to specific sites.
+Fine grained control over policies for specific sites.
 
 ## Compatibility
 
 <PolicyCompat policy="SitePolicies" />
 
+**CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 
-The policy is made up of a list of rules that are evaluated in order.
-Each can contain:
+## Examples
 
-- `Match` is a list of sites.
-  An empty list or missing property means to match all sites.
-- `Exceptions` is also a list of sites which when matched bypasses this set of rules.
-- `Policies` is an object defining the policies.
+<PolicyExample policy="SitePolicies" />
 
-Currently the only supported policies are:
-
-- `DisableJit` disables the JIT engine for the site when `true`.
-
-  > [!WARNING]
-  > When the JIT engine is disabled, some sites may be slow, experience breakages, and WebAssembly won't be executed.
-  > Be sure to scope `DisableJit` as narrowly as possible using `Match` patterns, or via exemptions using `Exceptions`.
-
-It is important to note that a site here refers to a registerable domain so `*.example.com` is a valid site but `*.com` is not. `*` can also be used to refer to all sites.
-
+A wildcard `*` can be used to refer to all sites.
 For example this setting would disable the JIT for only `*.example.com`:
 
 ```json
@@ -56,9 +44,29 @@ While this setting would disable the JIT on every site except `*.example.org`:
 ]
 ```
 
-## Examples
+## Values
 
-<PolicyExample policy="SitePolicies" />
+The policy is made up of a list of rules that are evaluated in order.
+Each rule can contain:
+
+- `Match`: a list of sites.
+  An empty list or missing property means to match all sites.
+- `Exceptions`: a list of sites which when matched bypasses this set of rules.
+- `Policies`: an object defining the site policies.
+
+> [!NOTE]
+> A "site" refers to a registerable domain, so `*.example.com` is a valid site but `*.com` is not.
+
+Currently the supported site policies are:
+
+- `DisableJit` disables the JIT engine for the site when `true`.
+
+  > [!WARNING]
+  > When the JIT engine is disabled, some sites may be slow, experience breakages, and WebAssembly won't be executed.
+  > Be sure to scope `DisableJit` as narrowly as possible using `Match` patterns, or via exemptions using `Exceptions`.
+
+- `HttpsOnly` stops the site from being loaded over plain HTTP when `true`.
+  When it is `false`, HTTP is explicitly allowed for the site, which is how you carve a site out of a broader rule.
 
 ## Windows (GPO)
 
@@ -69,7 +77,7 @@ Software\Policies\Mozilla\Firefox\SitePolicies (REG_MULTI_SZ) =
     "Exceptions": ["*.example.com"],
     "Policies": {
       "DisableJit": true
-    },
+    }
   }
 ]
 ```
@@ -91,7 +99,7 @@ Value (string):
     "Exceptions": ["*.example.com"],
     "Policies": {
       "DisableJit": true
-    },
+    }
   }
 ]'/>
 ```
@@ -116,3 +124,7 @@ Value (string):
   </array>
 </dict>
 ```
+
+## See also
+
+- [`HttpsOnlyMode`](/reference/policies/httpsonlymode/) policy covers all browsing and can be configured to let the user turn it off.

--- a/src/content/docs/reference/policies/SitePolicies.mdx
+++ b/src/content/docs/reference/policies/SitePolicies.mdx
@@ -6,6 +6,9 @@ category: "Browsing restrictions"
 
 Fine grained control over policies for specific sites.
 
+Use this to harden or restrict individual sites rather than the whole browser, for example turning the JIT engine off on untrusted sites or requiring HTTPS for a set of internal hosts.
+Each rule applies only to the sites it matches, so you can tighten the browser where it matters without changing behavior everywhere else.
+
 ## Compatibility
 
 <PolicyCompat policy="SitePolicies" />

--- a/src/content/docs/reference/policies/StartDownloadsInTempDirectory.mdx
+++ b/src/content/docs/reference/policies/StartDownloadsInTempDirectory.mdx
@@ -45,3 +45,9 @@ Value (string):
   <true/> | <false/>
 </dict>
 ```
+
+## See also
+
+- [`DefaultDownloadDirectory`](/reference/policies/defaultdownloaddirectory/) policy, which sets the default download directory.
+- [`DownloadDirectory`](/reference/policies/downloaddirectory/) policy, which sets and locks the download directory.
+- [`PromptForDownloadLocation`](/reference/policies/promptfordownloadlocation/) policy, which asks where to save each file before downloading.

--- a/src/content/docs/reference/policies/SupportMenu.mdx
+++ b/src/content/docs/reference/policies/SupportMenu.mdx
@@ -6,6 +6,9 @@ category: "Browser UI"
 
 Add a menuitem to the help menu for specifying support information.
 
+The item is added to the bottom of the Help menu, below a separator, so your own support contact sits alongside the built-in Firefox help entries.
+Selecting it opens the URL you specify in a new tab.
+
 ## Compatibility
 
 <PolicyCompat policy="SupportMenu" />
@@ -16,6 +19,12 @@ Add a menuitem to the help menu for specifying support information.
 ## Examples
 
 <PolicyExample policy="SupportMenu" />
+
+## Values
+
+- `Title`: a string label shown in the Help menu.
+- `URL`: a string with the URL that opens when the item is selected.
+- `AccessKey` (optional): a single character used as the keyboard shortcut for the item within the menu.
 
 ## Windows (GPO)
 

--- a/src/content/docs/reference/policies/UseSystemPrintDialog.mdx
+++ b/src/content/docs/reference/policies/UseSystemPrintDialog.mdx
@@ -6,6 +6,9 @@ category: "Printing"
 
 Use the system print dialog instead of the print preview window.
 
+Firefox normally opens its own [print dialog](https://support.mozilla.org/en-US/kb/how-print-web-pages-firefox), which combines the print preview and the print settings in a single panel.
+If this policy is set to `true`, Firefox skips that panel and opens the operating system print dialog directly, skipping the preview.
+
 ## Compatibility
 
 <PolicyCompat policy="UseSystemPrintDialog" />

--- a/src/content/docs/reference/policies/UserMessaging.mdx
+++ b/src/content/docs/reference/policies/UserMessaging.mdx
@@ -6,6 +6,11 @@ category: "Miscellaneous"
 
 Prevent Firefox from messaging the user in certain situations.
 
+Firefox shows a number of in-product messages that are unrelated to the page being viewed: [recommendations](https://support.mozilla.org/en-US/kb/extension-recommendations) for extensions and features based on the kind of sites visited, suggestions in the address bar, onboarding messages for new profiles, and information about Mozilla products in Settings.
+This policy turns those off individually, which is usually needed when users are not expected to install their own extensions or see product information.
+
+Each key covers one type of message, so setting one does not affect the others.
+
 ## Compatibility
 
 <PolicyCompat policy="UserMessaging" />
@@ -24,6 +29,7 @@ Prevent Firefox from messaging the user in certain situations.
 - `FeatureRecommendations`: If `false`, don't recommend browser features.
 - `UrlbarInterventions`: If `false`, don't offer Firefox specific suggestions in the URL bar.
 - `SkipOnboarding`: If `true`, don't show onboarding messages on the new tab page.
+  The [`OverrideFirstRunPage`](/reference/policies/overridefirstrunpage/) policy also turns onboarding off, and locks it.
 - `MoreFromMozilla`: If `false`, don't show the "More from Mozilla" section in Preferences. (Firefox 98)
 - `FirefoxLabs`: If `false`, don't show the "Firefox Labs" section in Preferences. (Firefox 130.0.1)
 - `Locked`: Prevents the user from changing user messaging preferences.

--- a/src/content/docs/reference/policies/UserMessaging.mdx
+++ b/src/content/docs/reference/policies/UserMessaging.mdx
@@ -9,7 +9,7 @@ Prevent Firefox from messaging the user in certain situations.
 Firefox shows a number of in-product messages that are unrelated to the page being viewed: [recommendations](https://support.mozilla.org/en-US/kb/extension-recommendations) for extensions and features based on the kind of sites visited, suggestions in the address bar, onboarding messages for new profiles, and information about Mozilla products in Settings.
 This policy turns those off individually, which is usually needed when users are not expected to install their own extensions or see product information.
 
-Each key covers one type of message, so setting one does not affect the others.
+Each message-specific key covers one type of message, so setting one does not affect the others.
 
 ## Compatibility
 

--- a/src/content/docs/reference/policies/VisualSearchEnabled.mdx
+++ b/src/content/docs/reference/policies/VisualSearchEnabled.mdx
@@ -4,6 +4,11 @@ description: "Enable or disable visual search."
 category: "Search"
 ---
 
+Enable or disable visual search.
+
+Visual search lets users search the web using an image on the page instead of typing a query, through [Google Lens](https://support.mozilla.org/en-US/kb/search-web-images-firefox-google-lens) in the context menu.
+It is only offered when Google is the default search engine, so removing Google with the [`SearchEngines`](/reference/policies/searchengines/) policy also takes the feature away.
+
 ## Compatibility
 
 <PolicyCompat policy="VisualSearchEnabled" />
@@ -39,7 +44,7 @@ Value (string):
 
 ```xml
 <dict>
-    <key>VisualSearchEnabled</key>
+  <key>VisualSearchEnabled</key>
   <true/> | <false/>
 </dict>
 ```


### PR DESCRIPTION
**Description:**

I went through the docs and flagged some areas for improvement. This PR cleans up:

- moving compat info out of prose up to compat section
- External links where necessary (product docs, technical references)
- Xrefs where policies had platform-specific equivalents or related concepts
- formatting fixes
- additional context

**Motivation:**

Increasing the quality of the docs

**Related issues and pull requests:**

Related to:

- [x] https://github.com/mozilla/enterprise-admin-reference/pull/277
- [x] #278
- [x] #279