### PR TITLE
fix: change DisableLocalPolicies callout type to type=caution

### DIFF
--- a/src/content/docs/reference/policies/DisableLocalPolicies.mdx
+++ b/src/content/docs/reference/policies/DisableLocalPolicies.mdx
@@ -13,5 +13,6 @@ Disable reading policies from local policy sources.
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 
-> [!CAUTION]
-> The policy cannot be applied by policies.json, Windows GPO or macOS plist.
+:::caution[Limitation]
+The policy cannot be applied by policies.json, Windows GPO or macOS plist.
+:::


### PR DESCRIPTION
<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
-->

**Description:**

Changes the callout  type to `type="caution"` and changes the title to "Limitation" in the `DisableLocalPolicies` docs.

<!-- ✍️ Summarize your changes in one or two sentences. -->

**Motivation:**

 The note that the policy cannot be set via a local policy provider is a configuration limitation, not a danger.

<!-- ❓ Why are you making these changes and how do they help? -->

**Related issues and pull requests:**

Fixes #282.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->
