### PR TITLE
feat: add some compat info to changelog for DefaultBrowserSettingEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added
 
-- `DefaultBrowserSettingEnabled` policy: Control whether the user can set Firefox as the default browser.
+- `DefaultBrowserSettingEnabled` policy: Control whether the user can set Firefox as the default browser. Ships in Firefox 154 and Firefox ESR 153.1.0. [#268](https://github.com/mozilla/enterprise-admin-reference/pull/268)
 - `DisableLocalPolicies` policy: Disable all local policy sources (policies.json, Windows GPO and macOS plist). [#216](https://github.com/mozilla/enterprise-admin-reference/pull/216)
 
 ### Changed


### PR DESCRIPTION

**Description:**

The proper fix should land in the schema, but noting in changelog for now.

**Motivation:**

Correcting the compat info.

**Related issues and pull requests:**

- Bug -> https://bugzilla.mozilla.org/show_bug.cgi?id=2051921#c17