### PR TITLE
feat: add SecurityLogging page, reference updates for 155

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -69,6 +69,7 @@ SPNEGO
 sslproxy
 SSPI
 subkeys
+subresource
 subresources
 SUMO
 systemconfig

--- a/src/content/docs/reference/policies/AIChatbot.mdx
+++ b/src/content/docs/reference/policies/AIChatbot.mdx
@@ -7,10 +7,10 @@ category: "Content settings"
 Configure the AI chatbot sidebar, including which built-in providers are available and the ability to add custom providers.
 For more information, see [Access AI chatbots in Firefox](https://support.mozilla.org/en-US/kb/ai-chatbot) on support.mozilla.org.
 
-> [!NOTE]
-> Currently, this is only implemented in Firefox Enterprise.
+## Compatibility
 
-**Compatibility:** Firefox Enterprise 149.0.0\
+<PolicyCompat policy="AIChatbot" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** `browser.ml.chat.enabled`, `browser.ml.chat.provider`, `browser.ml.chat.providers`, `browser.ml.chat.shortcuts`, `browser.ml.chat.prompts.0`, `browser.ml.chat.prompts.1`, `browser.ml.chat.prompts.2`, `browser.ml.chat.prompts.3`
 

--- a/src/content/docs/reference/policies/AccessConnector.mdx
+++ b/src/content/docs/reference/policies/AccessConnector.mdx
@@ -5,14 +5,15 @@ category: "Network security"
 ---
 
 Configure an Access Connector for proxying web traffic.
-When this policy is set, Firefox traffic matching the specified URL patterns is routed through the configured proxy.
+When this policy is set, Firefox routes traffic through the server given by `Host` and `Port`.
+If `MatchPatterns` is set, only URLs matching those patterns are routed through the connector.
 
-> [!NOTE]
-> Currently, this is only implemented in Firefox Enterprise.
+## Compatibility
 
-**Compatibility:** Firefox Enterprise 149.0.0\
+<PolicyCompat policy="AccessConnector" />
+
 **CCK2 Equivalent:** N/A\
-**Preferences Affected:** N/A
+**Preferences Affected:** `browser.ipProtection.autoStartEnabled`, `browser.ipProtection.enabled`, `browser.ipProtection.features.autoStart`, `browser.ipProtection.inclusion.match_patterns`, `browser.ipProtection.mode`, `browser.ipProtection.openedPanelWithLocation`, `browser.ipProtection.override.serverlist`
 
 ## Examples
 
@@ -23,8 +24,11 @@ When this policy is set, Firefox traffic matching the specified URL patterns is 
 - `Host`: A string that defines the hostname or IP address of the proxy server to use.
 - `Port`: A number defining the port number of the proxy server (e.g., `443`).
 - `MatchPatterns`: A list of URL match patterns for which traffic should be routed through the Access Connector.
+  If this is not set, all traffic is routed through the connector.
   See [Match patterns](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns) for syntax.
 - `Locked`: Prevents the user from changing Access Connector settings.
+  Unlike most policies, this defaults to `true`.
+  Set it to `false` to apply the settings as defaults that users can still change.
 
 ## Windows (GPO)
 

--- a/src/content/docs/reference/policies/CrashReportsSubmit.mdx
+++ b/src/content/docs/reference/policies/CrashReportsSubmit.mdx
@@ -6,7 +6,10 @@ category: "Cloud reporting"
 
 Configure crash report submission settings.
 
-**Compatibility:** Firefox Enterprise 154.0.0\
+## Compatibility
+
+<PolicyCompat policy="CrashReportsSubmit" />
+
 **Preferences Affected:** `browser.crashReports.unsubmittedCheck.enabled`, `browser.crashReports.unsubmittedCheck.autoSubmit2`, `browser.tabs.crashReporting.includeURL`, `browser.tabs.crashReporting.sendReport`
 
 > [!NOTE]

--- a/src/content/docs/reference/policies/DisableLocalPolicies.mdx
+++ b/src/content/docs/reference/policies/DisableLocalPolicies.mdx
@@ -6,10 +6,10 @@ category: "Miscellaneous"
 
 Disable reading policies from local policy sources.
 
-> [!NOTE]
-> Currently, this is only implemented in Firefox Enterprise.
+## Compatibility
 
-**Compatibility:** Firefox Enterprise 155.0.0\
+<PolicyCompat policy="DisableLocalPolicies" />
+
 **CCK2 Equivalent:** N/A\
 **Preferences Affected:** N/A
 

--- a/src/content/docs/reference/policies/SecurityLogging.mdx
+++ b/src/content/docs/reference/policies/SecurityLogging.mdx
@@ -1,0 +1,51 @@
+---
+title: "SecurityLogging"
+description: "Enable and configure security logging for security-relevant events."
+category: "Cloud reporting"
+---
+
+Enable and configure logging of security-relevant events, such as downloads, printing, add-on installs, and Safe Browsing detections.
+
+Each event is configured independently.
+When an event is logged, Firefox records it and submits it in the `enterprise` telemetry ping, which is kept separate from general Firefox telemetry.
+
+Values set by this policy are locked, so users cannot change them.
+
+## Compatibility
+
+<PolicyCompat policy="SecurityLogging" />
+
+**CCK2 Equivalent:** N/A\
+**Preferences Affected:** `browser.download.enterprise.telemetry.enabled`, `browser.download.enterprise.telemetry.fileLogging`, `browser.download.enterprise.telemetry.urlLogging`, `browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled`, `browser.policies.enterprise.telemetry.blocklistDomainBrowsed.urlLogging`, `browser.safebrowsing.enterprise.telemetry.unsafeDownload.enabled`, `browser.safebrowsing.enterprise.telemetry.unsafeDownload.urlLogging`, `browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.enabled`, `browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.urlLogging`, `extensions.enterprise.telemetry.addonInstall.enabled`, `print.enterprise.telemetry.printPage.enabled`, `print.enterprise.telemetry.printPage.urlLogging`
+
+## Examples
+
+<PolicyExample policy="SecurityLogging" />
+
+## Values
+
+Each key configures one event.
+Events and settings that are left out of the policy keep their defaults.
+The following event keys are available:
+
+- `AddonInstall`: Recorded when an add-on installation completes. This is the only event with no `UrlLogging` setting.
+- `BlocklistDomainBrowsed`: Recorded when a user browses to a site blocked by the [`WebsiteFilter`](/reference/policies/websitefilter/) policy.
+  `UrlLogging` applies to the requested URL, the URL that was blocked, and the referrer.
+- `Download`: Recorded when a download completes. This is the only event with a `FileLogging` setting.
+- `PrintPage`: Recorded when a page is printed.
+  `UrlLogging` applies to both the printed page URL and the top-level page URL.
+- `UnsafeDownload`: Recorded when download protection flags a download as dangerous, from a dangerous host, uncommon, or potentially unwanted.
+  The event is recorded whether or not the download was blocked.
+- `UnsafeSiteVisit`: Recorded when Safe Browsing flags a page, frame, or subresource, for example as malware or phishing.
+
+All keys accept the following sub-keys:
+
+- `Enabled`: A Boolean. If `false`, the event is not recorded. The default is `true`.
+- `UrlLogging`: Controls how much URL information the event records. The default is `full`.
+  - `full`: Log complete URLs, including paths and parameters. Any password in the URL is masked.
+  - `domain`: Log only URL hostnames.
+  - `none`: Do not log URL information.
+- `FileLogging`: Controls how much file information the `Download` event records. The default is `full`.
+  - `full`: Log filenames, file paths, extensions, and MIME types.
+  - `metadata`: Log only file extensions and MIME types.
+  - `none`: Do not log file information.

--- a/src/content/docs/reference/policies/Sync.mdx
+++ b/src/content/docs/reference/policies/Sync.mdx
@@ -6,12 +6,12 @@ category: "Local data storage"
 
 Controls whether [sync](https://www.firefox.com/en-US/features/sync/) should be enabled and which features should be enabled for syncing.
 
-> [!NOTE]
-> Currently, this is only implemented in Firefox Enterprise.
+## Compatibility
 
-**Compatibility:** Firefox Enterprise 150.0.0\
+<PolicyCompat policy="Sync" />
+
 **CCK2 Equivalent:** N/A\
-**Preferences Affected:** N/A
+**Preferences Affected:** `services.sync.engine.addons`, `services.sync.engine.addresses`, `services.sync.engine.bookmarks`, `services.sync.engine.creditcards`, `services.sync.engine.history`, `services.sync.engine.passwords`, `services.sync.engine.prefs`, `services.sync.engine.tabs`
 
 ## Examples
 
@@ -24,11 +24,13 @@ Controls whether [sync](https://www.firefox.com/en-US/features/sync/) should be 
 - `Bookmarks`: A Boolean. Controls whether syncing bookmarks should be enabled.
 - `Enabled`: A Boolean. Controls whether sync itself should be enabled.
 - `History`: A Boolean. Controls whether syncing history should be enabled.
-- `Locked`: A Boolean. Controls whether to lock the customized sync settings.
 - `OpenTabs`: A Boolean. Controls whether syncing open tabs should be enabled.
 - `Passwords`: A Boolean. Controls whether syncing passwords should be enabled.
 - `PaymentMethods`: A Boolean. Controls whether syncing payment methods should be enabled.
 - `Settings`: A Boolean. Controls whether syncing settings should be enabled.
+- `Locked`: A Boolean. Controls whether the settings are enforced, and whether `Enabled` applies at all.
+  If `Locked` is `true`, the Sync data type settings are locked so users cannot change them, and `Enabled` connects or disconnects sync.
+  Users can no longer turn sync on or off themselves, whether `Enabled` is `true` or `false`, and only a policy update can change it.
 
 ## Windows (GPO)
 

--- a/src/plugins/inject-oma-uri.mjs
+++ b/src/plugins/inject-oma-uri.mjs
@@ -14,6 +14,7 @@ const NO_ADMX_EQUIVALENT = new Set([
   "DisablePocket", // Deprecated, deliberately omitted upstream.
   "EnterprisePoliciesEnabled", // Registry bootstrap, outside the ADMX namespace.
   "MicrosoftEntraSSO", // macOS only.
+  "SecurityLogging", // Configured through the admin console, not local policy.
 ]);
 
 // TODO: Missing from `firefox.admx`


### PR DESCRIPTION
__Changes:__

* Compat data has landed for some policies, wiring that in
* New SecurityLogging doc page

**Motivation:**

Keeping docs up-to-date

**Related issues and pull requests:**

- [x] https://github.com/mozilla/enterprise-admin-reference/pull/300