### PR TITLE
feat: add docs pages for DLP

### DIFF
--- a/src/content/docs/reference/policies/ContentAnalysisTelemetry.mdx
+++ b/src/content/docs/reference/policies/ContentAnalysisTelemetry.mdx
@@ -1,10 +1,10 @@
 ---
 title: "ContentAnalysisTelemetry"
-description: "Enable and configure security logging when a DLP rule is triggered."
+description: "Enable and configure security logging when a Data Loss Prevention (DLP) rule is triggered."
 category: "Cloud reporting"
 ---
 
-Enable and configure logging of Data Loss Prevention events.
+Enable and configure logging of Data Loss Prevention (DLP) events.
 
 When a DLP rule is triggered, Firefox records the event and submits it in the `enterprise` telemetry ping, which is kept separate from general Firefox telemetry.
 Events are logged with full URLs by default, so this policy is normally used to turn logging off or to reduce what it records.
@@ -33,5 +33,5 @@ Values set by this policy are locked, so users cannot change them.
 ## See also
 
 - [`ContentAnalysis`](/reference/policies/contentanalysis/) policy configures DLP through an external agent.
-- [`DataLossPrevention`](/reference/policies/datalossprevention/) policy configures the built-in DLP rules.
+- [`DataLossPrevention`](/reference/policies/datalossprevention/) policy configures DLP through the built-in engine.
 - [`SecurityLogging`](/reference/policies/securitylogging/) policy covers other security-relevant events.

--- a/src/content/docs/reference/policies/ContentAnalysisTelemetry.mdx
+++ b/src/content/docs/reference/policies/ContentAnalysisTelemetry.mdx
@@ -1,0 +1,37 @@
+---
+title: "ContentAnalysisTelemetry"
+description: "Enable and configure security logging when a DLP rule is triggered."
+category: "Cloud reporting"
+---
+
+Enable and configure logging of Data Loss Prevention events.
+
+When a DLP rule is triggered, Firefox records the event and submits it in the `enterprise` telemetry ping, which is kept separate from general Firefox telemetry.
+Events are logged with full URLs by default, so this policy is normally used to turn logging off or to reduce what it records.
+
+Values set by this policy are locked, so users cannot change them.
+
+## Compatibility
+
+<PolicyCompat policy="ContentAnalysisTelemetry" />
+
+**CCK2 Equivalent:** N/A\
+**Preferences Affected:** `browser.contentanalysis.enterprise.telemetry.enabled`, `browser.contentanalysis.enterprise.telemetry.urlLogging`
+
+## Examples
+
+<PolicyExample policy="ContentAnalysisTelemetry" />
+
+## Values
+
+- `Enabled`: A Boolean. If `false`, DLP events are not recorded. The default is `true`.
+- `UrlLogging`: Controls how much URL information each event records. The default is `full`.
+  - `full`: Log complete URLs, including paths and parameters.
+  - `domain`: Log only URL hostnames.
+  - `none`: Do not log URL information.
+
+## See also
+
+- [`ContentAnalysis`](/reference/policies/contentanalysis/) policy configures DLP through an external agent.
+- [`DataLossPrevention`](/reference/policies/datalossprevention/) policy configures the built-in DLP rules.
+- [`SecurityLogging`](/reference/policies/securitylogging/) policy covers other security-relevant events.

--- a/src/content/docs/reference/policies/DataLossPrevention.mdx
+++ b/src/content/docs/reference/policies/DataLossPrevention.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DataLossPrevention"
-description: "Configure built-in Data Loss Prevention rules that warn on or block data actions per domain."
+description: "Configure built-in Data Loss Prevention (DLP) rules that warn on or block data actions per domain."
 category: "Cloud reporting"
 ---
 
@@ -36,11 +36,11 @@ Only one DLP service can be active:
   - `Name`: (**required**) An identifier for the rule, using lowercase letters, digits, and hyphens, up to 64 characters.
   - `Enabled`: A Boolean. A rule only takes effect when this is `true`.
   - `Actions`: (**required**) The data actions the rule covers, at least one of `TextPaste`, `FileUpload`, `FileDownload`, and `Print`.
-  - `Domains`: (**required**) The domains the rule applies to, at least one.
+  - `Domains`: (**required**) The domains the rule applies to, at least one. Use `*` to match all domains.
   - `ContentPatterns`: A list of regular expressions matched against the content of the operation.
     If a pattern is not a valid regular expression, the whole rule is dropped and the problem is reported in `about:policies#errors`.
   - `Type`: (**required**) What the rule does when it matches, either `warn` or `block`.
-  - `Message`: The text shown to the user when the rule triggers.
+  - `Message`: Text shown to the user when the rule triggers.
 
 ## See also
 

--- a/src/content/docs/reference/policies/DataLossPrevention.mdx
+++ b/src/content/docs/reference/policies/DataLossPrevention.mdx
@@ -1,0 +1,49 @@
+---
+title: "DataLossPrevention"
+description: "Configure built-in Data Loss Prevention rules that warn on or block data actions per domain."
+category: "Cloud reporting"
+---
+
+Configure built-in Data Loss Prevention (DLP) rules that warn on or block data actions per domain.
+
+Unlike [`ContentAnalysis`](/reference/policies/contentanalysis/), which hands each operation to an external agent, this policy is evaluated by the built-in DLP engine, so no agent has to be manually installed.
+
+Only one DLP service can be active:
+
+- If `ContentAnalysis` has `Enabled` set to `true`, the external agent (`ContentAnalysis`) wins and these rules are ignored.
+- If `ContentAnalysis` is absent, or present without enabling an agent, the built-in `DataLossPrevention` rules apply.
+
+## Compatibility
+
+<PolicyCompat policy="DataLossPrevention" />
+
+**CCK2 Equivalent:** N/A\
+**Preferences Affected:** `browser.contentanalysis.agent_name`, `browser.contentanalysis.agent_timeout`, `browser.contentanalysis.allow_url_regex_list`, `browser.contentanalysis.bypass_for_same_tab_operations`, `browser.contentanalysis.default_result`, `browser.contentanalysis.deny_url_regex_list`, `browser.contentanalysis.dlp_rules`, `browser.contentanalysis.enabled`, `browser.contentanalysis.interception_point.clipboard.enabled`, `browser.contentanalysis.interception_point.clipboard.plain_text_only`, `browser.contentanalysis.interception_point.download.enabled`, `browser.contentanalysis.interception_point.drag_and_drop.enabled`, `browser.contentanalysis.interception_point.drag_and_drop.plain_text_only`, `browser.contentanalysis.interception_point.file_upload.enabled`, `browser.contentanalysis.interception_point.print.enabled`, `browser.contentanalysis.show_blocked_result`, `browser.contentanalysis.timeout_result`, `browser.contentanalysis.use_wasm_backend`
+
+## Examples
+
+<PolicyExample policy="DataLossPrevention" />
+
+## Values
+
+- `FallbackResult`: What happens to an operation the engine cannot reach a verdict on, including a request that has timed out. The default is `block`.
+  - `block`: Deny the operation.
+  - `warn`: Warn the user and let them choose whether to continue.
+  - `allow`: Allow the operation.
+- `AllowUrlRegexList`: A space-separated list of regular expressions.
+  Operations on matching URLs are always allowed, without being checked against the rules.
+- `Rules`: The list of DLP rules. Each rule takes:
+  - `Name`: (**required**) An identifier for the rule, using lowercase letters, digits, and hyphens, up to 64 characters.
+  - `Enabled`: A Boolean. A rule only takes effect when this is `true`.
+  - `Actions`: (**required**) The data actions the rule covers, at least one of `TextPaste`, `FileUpload`, `FileDownload`, and `Print`.
+  - `Domains`: (**required**) The domains the rule applies to, at least one.
+  - `ContentPatterns`: A list of regular expressions matched against the content of the operation.
+    If a pattern is not a valid regular expression, the whole rule is dropped and the problem is reported in `about:policies#errors`.
+  - `Type`: (**required**) What the rule does when it matches, either `warn` or `block`.
+  - `Message`: The text shown to the user when the rule triggers.
+
+## See also
+
+- [`ContentAnalysisTelemetry`](/reference/policies/contentanalysistelemetry/) policy controls what is logged when a rule is triggered.
+- [`ContentAnalysis`](/reference/policies/contentanalysis/) policy configures DLP through an external agent.
+- [`SecurityLogging`](/reference/policies/securitylogging/) policy covers other security-relevant events.

--- a/src/plugins/inject-oma-uri.mjs
+++ b/src/plugins/inject-oma-uri.mjs
@@ -15,7 +15,6 @@ const NO_ADMX_EQUIVALENT = new Set([
   "DisableLocalPolicies", // Registry bootstrap, outside the ADMX namespace.
   "DisablePocket", // Deprecated, deliberately omitted upstream.
   "EnterprisePoliciesEnabled", // Registry bootstrap, outside the ADMX namespace.
-  "EnterpriseStorageEncryption", // Configured through the admin console, not local policy.
   "MicrosoftEntraSSO", // macOS only.
   "SecurityLogging", // Configured through the admin console, not local policy.
   "Watermark", // Configured through the admin console, not local policy.

--- a/src/plugins/inject-oma-uri.mjs
+++ b/src/plugins/inject-oma-uri.mjs
@@ -10,11 +10,15 @@ const DOC_URL = "https://mozilla.github.io/policy-templates/oma-uris";
 // Policies with no ADMX equivalent.
 const NO_ADMX_EQUIVALENT = new Set([
   "3rdparty", // The extension developer supplies their own ADMX.
+  "ContentAnalysisTelemetry", // Configured through the admin console, not local policy.
+  "DataLossPrevention", // Configured through the admin console, not local policy.
   "DisableLocalPolicies", // Registry bootstrap, outside the ADMX namespace.
   "DisablePocket", // Deprecated, deliberately omitted upstream.
   "EnterprisePoliciesEnabled", // Registry bootstrap, outside the ADMX namespace.
+  "EnterpriseStorageEncryption", // Configured through the admin console, not local policy.
   "MicrosoftEntraSSO", // macOS only.
   "SecurityLogging", // Configured through the admin console, not local policy.
+  "Watermark", // Configured through the admin console, not local policy.
 ]);
 
 // TODO: Missing from `firefox.admx`


### PR DESCRIPTION
**Description:**

Adds two reference pages for DLP

**Motivation:**

Making sure we have docs pages for new policies. 

- Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=2016141

**Related issues and pull requests:**

Follow-up from:

- [x] https://github.com/mozilla/enterprise-admin-reference/pull/300

