### PR TITLE
fix(ci): Only open PRs if the schema has diffs

### DIFF
--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [ -z "$(git status --porcelain schema/)" ]; then
+          if [ -z "$(git status --porcelain schema/policies-schema.json)" ]; then
             echo "No schema changes to commit."
             exit 0
           fi


### PR DESCRIPTION
**Description:**

`.source.json` pins the upstream branch tip, so it drifts whenever anything lands in enterprise-firefox. We're only looking at the schema content.

**Motivation:**

We shouldn't have empty schema-sync PRs.

**Related issues and pull requests:**

- [ ] https://github.com/mozilla/enterprise-admin-reference/pull/308
