### PR TITLE
feat: Add values section for reference docs [a-c]

### DIFF
--- a/src/content/docs/reference/policies/AllowFileSelectionDialogs.mdx
+++ b/src/content/docs/reference/policies/AllowFileSelectionDialogs.mdx
@@ -19,7 +19,7 @@ Enable or disable file selection dialogs.
 
 ## Values
 
-- Set to `true` to allow file selection dialogs. This is the same as not setting the policy.
+- Set to `true` to allow file selection dialogs. This is the same as omitting the policy.
 - Set to `false` to stop Firefox opening file selection dialogs. Downloads go straight to the download directory and the user cannot change that.
 
 ## Windows (GPO)

--- a/src/content/docs/reference/policies/AllowFileSelectionDialogs.mdx
+++ b/src/content/docs/reference/policies/AllowFileSelectionDialogs.mdx
@@ -17,6 +17,11 @@ Enable or disable file selection dialogs.
 
 <PolicyExample policy="AllowFileSelectionDialogs" />
 
+## Values
+
+- Set to `true` to allow file selection dialogs. This is the same as not setting the policy.
+- Set to `false` to stop Firefox opening file selection dialogs. Downloads go straight to the download directory and the user cannot change that.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/AllowedDomainsForApps.mdx
+++ b/src/content/docs/reference/policies/AllowedDomainsForApps.mdx
@@ -19,6 +19,13 @@ If this policy is enabled, users can only access Google Workspace using accounts
 
 <PolicyExample policy="AllowedDomainsForApps" />
 
+## Values
+
+`AllowedDomainsForApps` expects a comma-separated list of domains, sent to Google as the `X-GoogApps-Allowed-Domains` header:
+
+- A domain, such as `example.com`, allows Google Workspace accounts from that domain.
+- `consumer_accounts` allows personal Gmail accounts.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/AllowedDomainsForApps.mdx
+++ b/src/content/docs/reference/policies/AllowedDomainsForApps.mdx
@@ -24,7 +24,7 @@ If this policy is enabled, users can only access Google Workspace using accounts
 `AllowedDomainsForApps` expects a comma-separated list of domains, sent to Google as the `X-GoogApps-Allowed-Domains` header:
 
 - A domain, such as `example.com`, allows Google Workspace accounts from that domain.
-- `consumer_accounts` allows personal Gmail accounts.
+- `consumer_accounts`: a keyword that allows personal Gmail accounts alongside whichever Workspace domains you list. See the [Chrome equivalent](https://chromeenterprise.google/policies/allowed-domains-for-apps/) for more details.
 
 ## Windows (GPO)
 

--- a/src/content/docs/reference/policies/AppAutoUpdate.mdx
+++ b/src/content/docs/reference/policies/AppAutoUpdate.mdx
@@ -4,11 +4,10 @@ description: "Enable or disable **automatic** application update."
 category: "Device update settings"
 ---
 
-Enable or disable **automatic** application update.
+Enable or disable automatic application update.
 
-If set to `true`, application updates are installed without user approval within Firefox. The operating system might still require approval.
-
-If set to `false`, application updates are downloaded but the user can choose when to install the update.
+Allows application updates to be installed without user approval within Firefox, although the operating system might still require approval.
+When the policy is disabled, application updates are downloaded and the user can choose when to install the update.
 
 If you have disabled updates via [`DisableAppUpdate`](/reference/policies/disableappupdate/), this policy has no effect.
 
@@ -22,6 +21,11 @@ If you have disabled updates via [`DisableAppUpdate`](/reference/policies/disabl
 ## Examples
 
 <PolicyExample policy="AppAutoUpdate" />
+
+## Values
+
+- Set to `true` to install application updates without user approval, and prevent the user from turning automatic updates off. The operating system might still require approval.
+- Set to `false` to download updates but let the user choose when to install them, and prevent the user from turning automatic updates on.
 
 ## Windows (GPO)
 

--- a/src/content/docs/reference/policies/AppUpdatePin.mdx
+++ b/src/content/docs/reference/policies/AppUpdatePin.mdx
@@ -29,6 +29,13 @@ If you specify a version that doesn't exist, Firefox will update beyond that ver
 
 <PolicyExample policy="AppUpdatePin" />
 
+## Values
+
+`AppUpdatePin` expects a version prefix ending in a dot:
+
+- `MAJOR.`, such as `140.`, pins Firefox to the major version and allows every update within it.
+- `MAJOR.MINOR.`, such as `140.0.`, pins Firefox to the minor version and allows only patch updates within it.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/AppUpdateURL.mdx
+++ b/src/content/docs/reference/policies/AppUpdateURL.mdx
@@ -17,6 +17,10 @@ Change the URL for application update if you are providing Firefox updates from 
 
 <PolicyExample policy="AppUpdateURL" />
 
+## Values
+
+`AppUpdateURL` expects the URL of the update XML on your update server, such as `https://www.example.com/update.xml`.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/Authentication.mdx
+++ b/src/content/docs/reference/policies/Authentication.mdx
@@ -7,8 +7,6 @@ category: "Authentication"
 Configure sites that support integrated authentication.
 See [Integrated authentication](https://htmlpreview.github.io/?https://github.com/mdn/archived-content/blob/main/files/en-us/mozilla/integrated_authentication/raw.html) for more information.
 
-The `PrivateBrowsing` member enables integrated authentication in private browsing.
-
 ## Compatibility
 
 <PolicyCompat policy="Authentication" />
@@ -21,6 +19,20 @@ The `PrivateBrowsing` member enables integrated authentication in private browsi
 ## Examples
 
 <PolicyExample policy="Authentication" />
+
+## Values
+
+- `SPNEGO`: A list of sites permitted to use SPNEGO (Kerberos) authentication.
+- `Delegated`: A list of sites permitted to use Kerberos delegation.
+- `NTLM`: A list of sites permitted to use NTLM authentication.
+- `AllowNonFQDN`: Allows authentication for hosts that are not fully qualified domain names.
+  Accepts `SPNEGO` and `NTLM`, each a boolean.
+- `AllowProxies`: Allows authentication to proxies.
+  Accepts `SPNEGO` and `NTLM`, each a boolean.
+- `PrivateBrowsing`: Set to `true` to allow integrated authentication in private browsing.
+- `Locked`: Prevents the user from changing these settings.
+  Unlike most policies, this defaults to `true`.
+  Set it to `false` to apply the values as defaults that users can still change.
 
 ## Windows (GPO)
 

--- a/src/content/docs/reference/policies/AutoLaunchProtocolsFromOrigins.mdx
+++ b/src/content/docs/reference/policies/AutoLaunchProtocolsFromOrigins.mdx
@@ -21,6 +21,15 @@ This also means that you cannot specify a wildcard (`*`) for all origins.
 
 <PolicyExample policy="AutoLaunchProtocolsFromOrigins" />
 
+## Values
+
+Each entry in the list accepts the following keys:
+
+- `protocol` (required): The external protocol scheme, without the colon, such as `zoommtg`.
+- `allowed_origins` (required): A list of origins allowed to launch that protocol without a prompt.
+  Each origin is a scheme, hostname and optional port.
+  Paths and wildcards are not supported.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/AutofillAddressEnabled.mdx
+++ b/src/content/docs/reference/policies/AutofillAddressEnabled.mdx
@@ -20,6 +20,11 @@ See [Automatically fill in your address on web forms](https://support.mozilla.or
 
 <PolicyExample policy="AutofillAddressEnabled" />
 
+## Values
+
+- Set to `true` to save and autofill addresses, and prevent the user from changing it.
+- Set to `false` to stop saving and autofilling addresses, and prevent the user from changing it.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/AutofillCreditCardEnabled.mdx
+++ b/src/content/docs/reference/policies/AutofillCreditCardEnabled.mdx
@@ -19,6 +19,11 @@ This only applies when payment method autofill is enabled for a particular Firef
 
 <PolicyExample policy="AutofillCreditCardEnabled" />
 
+## Values
+
+- Set to `true` to save and autofill payment methods, and prevent the user from changing it.
+- Set to `false` to stop saving and autofilling payment methods, and prevent the user from changing it.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/BackgroundAppUpdate.mdx
+++ b/src/content/docs/reference/policies/BackgroundAppUpdate.mdx
@@ -28,6 +28,11 @@ Windows only.
 
 <PolicyExample policy="BackgroundAppUpdate" />
 
+## Values
+
+- Set to `true` to install updates in the background, and prevent the user from turning background updates off.
+- Set to `false` to stop updates being installed in the background, and prevent the user from turning them on.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/BlockAboutAddons.mdx
+++ b/src/content/docs/reference/policies/BlockAboutAddons.mdx
@@ -17,6 +17,11 @@ Block access to the Add-ons Manager (`about:addons`).
 
 <PolicyExample policy="BlockAboutAddons" />
 
+## Values
+
+- Set to `true` to block access to the Add-ons Manager (`about:addons`).
+- Set to `false` to leave the Add-ons Manager available. This is the same as not setting the policy.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/BlockAboutConfig.mdx
+++ b/src/content/docs/reference/policies/BlockAboutConfig.mdx
@@ -17,6 +17,11 @@ Block access to Advanced Preferences (`about:config`).
 
 <PolicyExample policy="BlockAboutConfig" />
 
+## Values
+
+- Set to `true` to block access to `about:config`. This also turns off browser chrome debugging (`devtools.chrome.enabled`).
+- Set to `false` to leave `about:config` available. This is the same as not setting the policy.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/BlockAboutProfiles.mdx
+++ b/src/content/docs/reference/policies/BlockAboutProfiles.mdx
@@ -17,6 +17,11 @@ Block access to About Profiles (`about:profiles`).
 
 <PolicyExample policy="BlockAboutProfiles" />
 
+## Values
+
+- Set to `true` to block the profile pages: `about:profiles`, `about:profilemanager`, `about:editprofile`, `about:newprofile` and `about:deleteprofile`.
+- Set to `false` to leave the profile pages available. This is the same as not setting the policy.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/BlockAboutSupport.mdx
+++ b/src/content/docs/reference/policies/BlockAboutSupport.mdx
@@ -17,6 +17,11 @@ Block access to Troubleshooting Information (`about:support`).
 
 <PolicyExample policy="BlockAboutSupport" />
 
+## Values
+
+- Set to `true` to block access to troubleshooting information (`about:support`).
+- Set to `false` to leave `about:support` available. This is the same as not setting the policy.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/Bookmarks.mdx
+++ b/src/content/docs/reference/policies/Bookmarks.mdx
@@ -9,9 +9,6 @@ category: "Bookmarks"
 > The `Bookmarks` policy will continue to be supported for backwards-compatibility purposes.
 
 Add bookmarks in either the bookmarks toolbar or menu.
-Only `Title` and `URL` are required.
-If `Placement` is not specified, the bookmark will be placed on the toolbar.
-If `Folder` is specified, it is automatically created and bookmarks with the same folder name are grouped together.
 
 If you want to clear all bookmarks set with this policy, you can set the value to an empty array (`[]`). This can be on Windows via the new Bookmarks (JSON) policy available with GPO and Intune.
 
@@ -25,6 +22,18 @@ If you want to clear all bookmarks set with this policy, you can set the value t
 ## Examples
 
 <PolicyExample policy="Bookmarks" />
+
+## Values
+
+Each entry in the list accepts the following keys:
+
+- `Title` (required): The name shown for the bookmark.
+- `URL` (required): The address the bookmark opens.
+- `Favicon`: The URL of an icon to show for the bookmark.
+- `Placement`: `toolbar` adds the bookmark to the bookmarks toolbar, `menu` adds it to the bookmarks menu.
+  Defaults to `toolbar`.
+- `Folder`: The name of a folder to put the bookmark in.
+  The folder is created if it doesn't exist, and bookmarks that name the same folder are grouped together.
 
 ## Windows (GPO)
 

--- a/src/content/docs/reference/policies/BrowserDataBackup.mdx
+++ b/src/content/docs/reference/policies/BrowserDataBackup.mdx
@@ -21,6 +21,20 @@ Backup and restore can be disabled individually.
 
 <PolicyExample policy="BrowserDataBackup" />
 
+## Values
+
+`BrowserDataBackup` accepts either a boolean or an object.
+When set as a boolean:
+
+- Set to `true` to allow backup and restore of profile data, and lock both settings.
+- Set to `false` to disable backup and restore of profile data, and lock both settings.
+
+When set as an object, backup and restore can be controlled separately.
+Both keys are locked, and a key that is left out keeps its existing value:
+
+- `AllowBackup`: Set to `false` to stop profile data being backed up.
+- `AllowRestore`: Set to `false` to stop a profile being restored from a backup.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/CNSA2KeyAgreementEnabled.mdx
+++ b/src/content/docs/reference/policies/CNSA2KeyAgreementEnabled.mdx
@@ -23,6 +23,11 @@ Setting this policy locks the preference, whether the value is `true` or `false`
 
 <PolicyExample policy="CNSA2KeyAgreementEnabled" />
 
+## Values
+
+- Set to `true` to enable ML-KEM-1024 key agreement, and prevent the user from changing it.
+- Set to `false` to disable ML-KEM-1024 key agreement, and prevent the user from changing it.
+
 ## Windows (GPO)
 
 ```

--- a/src/content/docs/reference/policies/CaptivePortal.mdx
+++ b/src/content/docs/reference/policies/CaptivePortal.mdx
@@ -17,6 +17,11 @@ Enable or disable the detection of captive portals.
 
 <PolicyExample policy="CaptivePortal" />
 
+## Values
+
+- Set to `true` to enable captive portal detection, and prevent the user from changing it.
+- Set to `false` to disable captive portal detection, and prevent the user from changing it.
+
 ## Windows (GPO)
 
 ```


### PR DESCRIPTION
**Description:**

Add a `## Values` section to all reference docs. 

**Motivation:**

Sometimes it's obvious what a policy does, but this assumption can leave room for error. When we have a values section enforced, then we are explicit at the cost of stating the obvious. It's worth having the info on the page and have experts skip it rather than omit the info and have beginners fail because we don't list values.